### PR TITLE
Patch missing Organization mapping

### DIFF
--- a/VirtoCommerce.OrderModule.Data/Model/AddressEntity.cs
+++ b/VirtoCommerce.OrderModule.Data/Model/AddressEntity.cs
@@ -89,6 +89,7 @@ namespace VirtoCommerce.OrderModule.Data.Model
             target.LastName = LastName;
             target.Line1 = Line1;
             target.Line2 = Line2;
+            target.Organization = Organization;
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
@tatarincev The mapping for Organization is missing from the Order Address entity patch.