### PR TITLE
Bugs/60 order details disappearing

### DIFF
--- a/VirtoCommerce.OrderModule.Data/Model/OperationEntity.cs
+++ b/VirtoCommerce.OrderModule.Data/Model/OperationEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -8,6 +8,7 @@ using System.Reflection;
 using Omu.ValueInjecter;
 using VirtoCommerce.Domain.Commerce.Model;
 using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.OrderModule.Data.Utilities;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.OrderModule.Data.Model
@@ -40,7 +41,7 @@ namespace VirtoCommerce.OrderModule.Data.Model
 
             operation.InjectFrom(this);
 
-            operation.ChildrenOperations = GetAllChildOperations(operation);
+            operation.ChildrenOperations = OperationUtilities.GetAllChildOperations(operation);
             return operation;
         }
 
@@ -70,38 +71,6 @@ namespace VirtoCommerce.OrderModule.Data.Model
             operation.CancelReason = CancelReason;
             operation.IsApproved = IsApproved;
             operation.Sum = Sum;
-        }
-
-        private static IEnumerable<IOperation> GetAllChildOperations(IOperation operation)
-        {
-            var retVal = new List<IOperation>();
-            var objectType = operation.GetType();
-
-            var properties = objectType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            var childOperations = properties.Where(x => x.PropertyType.GetInterface(typeof(IOperation).Name) != null)
-                                    .Select(x => (IOperation)x.GetValue(operation)).Where(x => x != null).ToList();
-
-            foreach (var childOperation in childOperations)
-            {
-                retVal.Add(childOperation);
-            }
-
-            //Handle collection and arrays
-            var collections = properties.Where(p => p.GetIndexParameters().Length == 0)
-                                        .Select(x => x.GetValue(operation, null))
-                                        .Where(x => x is IEnumerable && !(x is string))
-                                        .Cast<IEnumerable>();
-
-            foreach (var collection in collections)
-            {
-                foreach (var childOperation in collection.OfType<IOperation>())
-                {
-                    retVal.Add(childOperation);
-                }
-            }
-
-            return retVal;
         }
     }
 }

--- a/VirtoCommerce.OrderModule.Data/Utilities/OperationUtilities.cs
+++ b/VirtoCommerce.OrderModule.Data/Utilities/OperationUtilities.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using VirtoCommerce.Domain.Commerce.Model;
+
+namespace VirtoCommerce.OrderModule.Data.Utilities
+{
+    public static class OperationUtilities
+    {
+        public static IEnumerable<IOperation> GetAllChildOperations(IOperation operation)
+        {
+            var retVal = new List<IOperation>();
+            var objectType = operation.GetType();
+
+            var properties = objectType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            var childOperations = properties.Where(x => x.PropertyType.GetInterface(typeof(IOperation).Name) != null)
+                .Select(x => (IOperation)x.GetValue(operation)).Where(x => x != null).ToList();
+
+            foreach (var childOperation in childOperations)
+            {
+                retVal.Add(childOperation);
+            }
+
+            //Handle collection and arrays
+            var collections = properties.Where(p => p.GetIndexParameters().Length == 0)
+                .Select(x => x.GetValue(operation, null))
+                .Where(x => x is IEnumerable && !(x is string))
+                .Cast<IEnumerable>();
+
+            foreach (var collection in collections)
+            {
+                foreach (var childOperation in collection.OfType<IOperation>())
+                {
+                    retVal.Add(childOperation);
+                }
+            }
+
+            return retVal;
+        }
+    }
+}

--- a/VirtoCommerce.OrderModule.Data/Utilities/OperationUtilities.cs
+++ b/VirtoCommerce.OrderModule.Data/Utilities/OperationUtilities.cs
@@ -6,8 +6,17 @@ using VirtoCommerce.Domain.Commerce.Model;
 
 namespace VirtoCommerce.OrderModule.Data.Utilities
 {
+    /// <summary>
+    /// Common operations for different implementations of the <see cref="IOperation"/> interface.
+    /// </summary>
     public static class OperationUtilities
     {
+        /// <summary>
+        /// Builds a list of all child operations related to the given operation.
+        /// Child operations are collected from properties of given operation using reflection.
+        /// </summary>
+        /// <param name="operation">The requested operation.</param>
+        /// <returns>List of all child operations of the <paramref name="operation"/>.</returns>
         public static IEnumerable<IOperation> GetAllChildOperations(IOperation operation)
         {
             var retVal = new List<IOperation>();

--- a/VirtoCommerce.OrderModule.Data/VirtoCommerce.OrderModule.Data.csproj
+++ b/VirtoCommerce.OrderModule.Data/VirtoCommerce.OrderModule.Data.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Services\CustomerOrderServiceImpl.cs" />
     <Compile Include="Services\DefaultCustomerOrderTotalsCalculator.cs" />
     <Compile Include="Services\ICustomerOrderBuilder.cs" />
+    <Compile Include="Utilities\OperationUtilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/VirtoCommerce.OrderModule.Web/Controllers/Api/OrderModuleController.cs
+++ b/VirtoCommerce.OrderModule.Web/Controllers/Api/OrderModuleController.cs
@@ -169,7 +169,6 @@ namespace VirtoCommerce.OrderModule.Web.Controllers.Api
         {
             _totalsCalculator.CalculateTotals(order);
             return Ok(order);
-
         }
 
         /// <summary>

--- a/VirtoCommerce.OrderModule.Web/JsonConverters/PolymorphicOperationJsonConverter.cs
+++ b/VirtoCommerce.OrderModule.Web/JsonConverters/PolymorphicOperationJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -8,6 +8,7 @@ using VirtoCommerce.Domain.Payment.Model;
 using VirtoCommerce.Domain.Payment.Services;
 using VirtoCommerce.Domain.Shipping.Model;
 using VirtoCommerce.Domain.Shipping.Services;
+using VirtoCommerce.OrderModule.Data.Utilities;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.OrderModule.Web.JsonConverters
@@ -71,6 +72,13 @@ namespace VirtoCommerce.OrderModule.Web.JsonConverters
             }
 
             serializer.Populate(obj.CreateReader(), retVal);
+
+            // The ChildrenOperations property was reset on lines 57-61, so now we rebuild it
+            if (operation != null)
+            {
+                operation.ChildrenOperations = OperationUtilities.GetAllChildOperations(operation);
+            }
+
             return retVal;
         }
 


### PR DESCRIPTION
The reason of #60 was quite simple:
1. After the payment details was changed, frontend sent the updated order to backend to recalculate totals.
2. While deserializing the order received from frontend, backend intentionally [reset](https://github.com/VirtoCommerce/vc-module-order/blob/master/VirtoCommerce.OrderModule.Web/JsonConverters/PolymorphicOperationJsonConverter.cs#L55) the `childrenOperations` property of the order details.
3. Backend did the recalculation and returned the recalculated order to frontend. `ChildrenOperations` property was still null.
4. After receiving the recalculated order, frontend attempted to display it's details. But, because of `childrenOperations` being cleared on step 2, the graph of order operations also cleared.

So, to fix it, I rebuild the `ChildrenOperations` list on the order received from frontend. There already was the code doing exactly this in `OperationEntity`, so I extracted it to `OperationUtilities` class and called it in `PolymorphicOperationJsonConverter` during deserialization. It solved the issue.