### PR TITLE
CartModule, 28: renamed controller method parameter to eliminate Swagger operation path conflict

### DIFF
--- a/VirtoCommerce.OrderModule.Web/Controllers/Api/OrderModuleController.cs
+++ b/VirtoCommerce.OrderModule.Web/Controllers/Api/OrderModuleController.cs
@@ -234,18 +234,18 @@ namespace VirtoCommerce.OrderModule.Web.Controllers.Api
         /// <summary>
         /// Create new customer order based on shopping cart.
         /// </summary>
-        /// <param name="cartId">shopping cart id</param>
+        /// <param name="id">shopping cart id</param>
         [HttpPost]
         [ResponseType(typeof(CustomerOrder))]
-        [Route("{cartId}")]
+        [Route("{id}")]
         [CheckPermission(Permission = OrderPredefinedPermissions.Create)]
-        public async Task<IHttpActionResult> CreateOrderFromCart(string cartId)
+        public async Task<IHttpActionResult> CreateOrderFromCart(string id)
         {
             CustomerOrder retVal;
 
-            using (await AsyncLock.GetLockByKey(cartId).LockAsync())
+            using (await AsyncLock.GetLockByKey(id).LockAsync())
             {
-                var cart = _cartService.GetByIds(new[] { cartId }).FirstOrDefault();
+                var cart = _cartService.GetByIds(new[] { id }).FirstOrDefault();
                 retVal = _customerOrderBuilder.PlaceCustomerOrderFromCart(cart);
             }
 


### PR DESCRIPTION
This PR is a part of the VirtoCommerce/vc-module-cart#28 and fixes Swagger validation error with message `Equivalent paths are not allowed.` This error was caused by multiple `OrderModuleController` methods having similar (but not equal) routes:
* `OrderModuleController.GetById` available by GET at `api/order/customerOrders/{id}`;
* `OrderModuleController.CreateOrderFromCart` available by POST at `api/order/customerOrders/{cartId}`.
This caused Swashbuckle to create multiple entries with similar paths, and it caused Swagger validation to fail.

To solve this issue, I've renamed the parameter of the `CreateOrderFromCart` to `id`. Now `GetById` and `CreateOrderFromCart` are both available at `api/order/customerOrders/{id}`, and Swashbuckle groups them to one entry. Note that HTTP methods are still different, so this change *probably* shouldn't break action routing.