### PR TITLE
69: concurrency fix for inventory adjustment

### DIFF
--- a/VirtoCommerce.OrderModule.Data/App.config
+++ b/VirtoCommerce.OrderModule.Data/App.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -48,31 +48,6 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
 
 
         /// <summary>
-        /// Handles the order change event immediately, without using Hangfire. 
-        /// This method is intended to use in unit tests and should not be called by the production code.
-        /// </summary>
-        /// <param name="message">Order changed event to handle.</param>
-        public virtual void HandleImmediately(OrderChangedEvent message)
-        {
-            if (_settingsManager.GetValue("Order.AdjustInventory", true))
-            {
-                foreach (var changedEntry in message.ChangedEntries)
-                {
-                    var customerOrder = changedEntry.OldEntry;
-                    //Do not process prototypes
-                    if (!customerOrder.IsPrototype)
-                    {
-                        var itemChanges = GetProductInventoryChangesFor(changedEntry);
-                        if (itemChanges.Any())
-                        {
-                            TryAdjustOrderInventoryBackgroundJob(itemChanges);
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
         /// Handles the order changed event by queueing a Hangfire task that adjusts inventories.
         /// </summary>
         /// <param name="message">Order changed event to handle.</param>
@@ -145,7 +120,13 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
             }
         }
 
-        protected virtual ProductInventoryChange[] GetProductInventoryChangesFor(GenericChangedEntry<CustomerOrder> changedEntry)
+        /// <summary>
+        /// Forms a list of product inventory changes for inventory adjustment. This method is intended for unit-testing only,
+        /// and there should be no need to call it from the production code.
+        /// </summary>
+        /// <param name="changedEntry">The entry that describes changes made to order.</param>
+        /// <returns>Array of required product inventory changes.</returns>
+        public virtual ProductInventoryChange[] GetProductInventoryChangesFor(GenericChangedEntry<CustomerOrder> changedEntry)
         {
             var customerOrder = changedEntry.NewEntry;
             var customerOrderShipments = customerOrder.Shipments?.ToArray();

--- a/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -31,12 +31,35 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
         private readonly IInventoryService _inventoryService;
         private readonly ISettingsManager _settingsManager;
         private readonly IStoreService _storeService;
+        private readonly IBackgroundJobClient _backgroundJobClient;
 
-        public AdjustInventoryOrderChangedEventHandler(IInventoryService inventoryService, IStoreService storeService, ISettingsManager settingsManager)
+        /// <summary>
+        /// Constructor to use in unit tests. Provides the ability to override the implementation of <see cref="IBackgroundJobClient"/>
+        /// to allow mocking Hangfire job queue.
+        /// </summary>
+        /// <param name="inventoryService">Inventory service to use for adjusting inventories.</param>
+        /// <param name="storeService">Implementation of store service.</param>
+        /// <param name="settingsManager">Implementation of settings manager.</param>
+        /// <param name="backgroundJobClient">Background job client that will be used to queue background jobs.</param>
+        public AdjustInventoryOrderChangedEventHandler(IInventoryService inventoryService, IStoreService storeService,
+            ISettingsManager settingsManager, IBackgroundJobClient backgroundJobClient)
         {
             _inventoryService = inventoryService;
             _settingsManager = settingsManager;
             _storeService = storeService;
+            _backgroundJobClient = backgroundJobClient;
+        }
+
+        /// <summary>
+        /// Constructor to use outside of unit tests. It uses the default background job client implementation.
+        /// </summary>
+        /// <param name="inventoryService">Inventory service to use for adjusting inventories.</param>
+        /// <param name="storeService">Implementation of store service.</param>
+        /// <param name="settingsManager">Implementation of settings manager.</param>
+        public AdjustInventoryOrderChangedEventHandler(IInventoryService inventoryService, IStoreService storeService,
+            ISettingsManager settingsManager)
+            : this(inventoryService, storeService, settingsManager, new BackgroundJobClient())
+        {
         }
 
 

--- a/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -54,19 +54,19 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
                     }
 
                     var itemChanges = GetLineItemChangesFor(changedEntry);
-                    BackgroundJob.Enqueue(() => TryAdjustOrderInventoryBackgroundJob(changedEntry.EntryState, itemChanges));
+                    BackgroundJob.Enqueue(() => TryAdjustOrderInventoryBackgroundJob(itemChanges));
                 }
             }
             return Task.CompletedTask;
         }
 
         [DisableConcurrentExecution(60 * 60 * 24)]
-        public void TryAdjustOrderInventoryBackgroundJob(EntryState entryState, OrderLineItemChange[] orderLineItemChanges)
+        public void TryAdjustOrderInventoryBackgroundJob(OrderLineItemChange[] orderLineItemChanges)
         {
-            TryAdjustOrderInventory(entryState, orderLineItemChanges);
+            TryAdjustOrderInventory(orderLineItemChanges);
         }
 
-        protected virtual void TryAdjustOrderInventory(EntryState entryState, OrderLineItemChange[] orderLineItemChanges)
+        protected virtual void TryAdjustOrderInventory(OrderLineItemChange[] orderLineItemChanges)
         {
             var inventoryAdjustments = new HashSet<InventoryInfo>();
             //Load all inventories records for all changes and old order items
@@ -81,7 +81,7 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
             _inventoryService.UpsertInventories(inventoryAdjustments);
         }
 
-        [Obsolete("This method is not used anymore. Please use the TryAdjustOrderInventory(EntryState, OrderLineItemChange[]) method instead.")]
+        [Obsolete("This method is not used anymore. Please use the TryAdjustOrderInventory(OrderLineItemChange[]) method instead.")]
         protected virtual void TryAdjustOrderInventory(GenericChangedEntry<CustomerOrder> changedEntry)
         {
             var customerOrder = changedEntry.OldEntry;
@@ -91,7 +91,7 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
             }
 
             var itemChanges = GetLineItemChangesFor(changedEntry);
-            TryAdjustOrderInventory(changedEntry.EntryState, itemChanges);
+            TryAdjustOrderInventory(itemChanges);
         }
 
         protected virtual OrderLineItemChange[] GetLineItemChangesFor(GenericChangedEntry<CustomerOrder> changedEntry)

--- a/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -31,45 +31,58 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
         private readonly IInventoryService _inventoryService;
         private readonly ISettingsManager _settingsManager;
         private readonly IStoreService _storeService;
-        private readonly IBackgroundJobClient _backgroundJobClient;
 
         /// <summary>
-        /// Constructor to use in unit tests. Provides the ability to override the implementation of <see cref="IBackgroundJobClient"/>
-        /// to allow mocking Hangfire job queue.
-        /// </summary>
-        /// <param name="inventoryService">Inventory service to use for adjusting inventories.</param>
-        /// <param name="storeService">Implementation of store service.</param>
-        /// <param name="settingsManager">Implementation of settings manager.</param>
-        /// <param name="backgroundJobClient">Background job client that will be used to queue background jobs.</param>
-        public AdjustInventoryOrderChangedEventHandler(IInventoryService inventoryService, IStoreService storeService,
-            ISettingsManager settingsManager, IBackgroundJobClient backgroundJobClient)
-        {
-            _inventoryService = inventoryService;
-            _settingsManager = settingsManager;
-            _storeService = storeService;
-            _backgroundJobClient = backgroundJobClient;
-        }
-
-        /// <summary>
-        /// Constructor to use outside of unit tests. It uses the default background job client implementation.
+        /// Constructor.
         /// </summary>
         /// <param name="inventoryService">Inventory service to use for adjusting inventories.</param>
         /// <param name="storeService">Implementation of store service.</param>
         /// <param name="settingsManager">Implementation of settings manager.</param>
         public AdjustInventoryOrderChangedEventHandler(IInventoryService inventoryService, IStoreService storeService,
             ISettingsManager settingsManager)
-            : this(inventoryService, storeService, settingsManager, new BackgroundJobClient())
         {
+            _inventoryService = inventoryService;
+            _settingsManager = settingsManager;
+            _storeService = storeService;
         }
 
 
+        /// <summary>
+        /// Handles the order change event immediately, without using Hangfire. 
+        /// This method is intended to use in unit tests and should not be called by the production code.
+        /// </summary>
+        /// <param name="message">Order changed event to handle.</param>
+        public virtual void HandleImmediately(OrderChangedEvent message)
+        {
+            if (_settingsManager.GetValue("Order.AdjustInventory", true))
+            {
+                foreach (var changedEntry in message.ChangedEntries)
+                {
+                    var customerOrder = changedEntry.OldEntry;
+                    //Do not process prototypes
+                    if (!customerOrder.IsPrototype)
+                    {
+                        var itemChanges = GetProductInventoryChangesFor(changedEntry);
+                        if (itemChanges.Any())
+                        {
+                            TryAdjustOrderInventoryBackgroundJob(itemChanges);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the order changed event by queueing a Hangfire task that adjusts inventories.
+        /// </summary>
+        /// <param name="message">Order changed event to handle.</param>
+        /// <returns>A task that allows to <see langword="await"/> this method.</returns>
         public virtual Task Handle(OrderChangedEvent message)
         {
             if (_settingsManager.GetValue("Order.AdjustInventory", true))
             {
                 foreach (var changedEntry in message.ChangedEntries)
                 {
-                    //Skip prototypes
                     var customerOrder = changedEntry.OldEntry;
                     //Do not process prototypes
                     if (!customerOrder.IsPrototype)

--- a/VirtoCommerce.OrderModule.Data/VirtoCommerce.OrderModule.Data.csproj
+++ b/VirtoCommerce.OrderModule.Data/VirtoCommerce.OrderModule.Data.csproj
@@ -53,11 +53,17 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="Hangfire.Core, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>..\packages\valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net46\StackExchange.Redis.dll</HintPath>

--- a/VirtoCommerce.OrderModule.Data/packages.config
+++ b/VirtoCommerce.OrderModule.Data/packages.config
@@ -5,7 +5,9 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.13" targetFramework="net461" />

--- a/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
+++ b/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Moq;
 using VirtoCommerce.Domain.Common.Events;
-using VirtoCommerce.Domain.Inventory.Model;
 using VirtoCommerce.Domain.Inventory.Services;
-using VirtoCommerce.Domain.Order.Events;
 using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Domain.Store.Services;
 using VirtoCommerce.OrderModule.Data.Handlers;
 using VirtoCommerce.Platform.Core.Common;
@@ -15,257 +13,159 @@ using Xunit;
 
 namespace VirtoCommerce.OrderModule.Test
 {
+    [CLSCompliant(false)]
     public class OrderInventoryAdjustmentTests
     {
-        private class InventoryInfoEqualityComparer : IEqualityComparer<InventoryInfo>
+        private const string TestStoreId = "TestStore";
+        private const string TestFulfillmentCenterId = "TestFulfillmentCenter";
+
+        private static readonly CustomerOrder InitialOrder = new CustomerOrder
         {
-            public bool Equals(InventoryInfo x, InventoryInfo y)
+            StoreId = TestStoreId,
+            Items = new List<LineItem>
             {
-                if (Object.ReferenceEquals(x, y))
-                    return true;
-
-                if (x == null || y == null)
-                    return false;
-
-                return x.ProductId == y.ProductId &&
-                       x.InStockQuantity == y.InStockQuantity;
+                new LineItem
+                {
+                    Id = "{01234567-89ab-cdef-0123-456789abcdef}",
+                    ProductId = "shoes",
+                    Quantity = 2
+                },
+                new LineItem
+                {
+                    Id = "{abcdef01-2345-6789-abcd-ef0123456789}",
+                    ProductId = "t-shirt",
+                    Quantity = 2
+                }
             }
+        };
 
-            public int GetHashCode(InventoryInfo obj)
+        private static readonly CustomerOrder ChangedOrder = new CustomerOrder
+        {
+            StoreId = TestStoreId,
+            Items = new List<LineItem>
             {
-                return obj.GetHashCode();
+                new LineItem
+                {
+                    Id = "{01234567-89ab-cdef-0123-456789abcdef}",
+                    ProductId = "shoes",
+                    Quantity = 5
+                },
+                new LineItem
+                {
+                    Id = "{fedcba98-7654-3210-0123-456789abcdef}",
+                    ProductId = "t-shirt-new",
+                    Quantity = 1
+                }
             }
-        }
+        };
 
-        private readonly Mock<IInventoryService> _inventoryServiceMock;
-        private readonly Mock<IStoreService> _storeServiceMock;
-        private readonly Mock<ISettingsManager> _settingsManagerMock;
-        private readonly AdjustInventoryOrderChangedEventHandler _targetHandler;
-
-        public OrderInventoryAdjustmentTests()
+        public static readonly IList<object[]> TestData = new List<object[]>
         {
-            _inventoryServiceMock = new Mock<IInventoryService>();
-
-            _storeServiceMock = new Mock<IStoreService>();
-
-            _settingsManagerMock = new Mock<ISettingsManager>();
-            _settingsManagerMock.Setup(x => x.GetValue("Order.AdjustInventory", It.IsAny<bool>()))
-                .Returns(true);
-
-            _targetHandler = new AdjustInventoryOrderChangedEventHandler(_inventoryServiceMock.Object,
-                _storeServiceMock.Object, _settingsManagerMock.Object);
-        }
-
-        [Fact]
-        public void AdjustInventoryHandler_AdjustsInventory_OnLineItemQuantityChange()
-        {
-            // Arrange
-            var oldOrder = CreateTestOrder("TESTORDER-000001");
-
-            var newOrder = CreateTestOrder("TESTORDER-000001");
-            var newOrderItems = newOrder.Items.ToList();
-
-            // Adjusting quantity for the first item. This should cause taking 3 pieces of "shoes" from the inventory.
-            newOrderItems[0].Quantity += 3;
-
-            // Changing Id and ProductId for the second item and adjusting its quantity. This will be treated as removal
-            // of "t-shirt" line item and addition of "t-shirt-new" line item, so it should cause the following changes:
-            // - taking 1 piece of "t-shirt-new" from the inventory;
-            // - returning 2 pieces of "t-shirt" to the inventory.
-            newOrderItems[1].Id = "{fedcba98-7654-3210-0123-456789abcdef}";
-            newOrderItems[1].ProductId = "t-shirt-new";
-            newOrderItems[1].Quantity = 1;
-
-            var changedEntries = new[] { new GenericChangedEntry<CustomerOrder>(newOrder, oldOrder, EntryState.Modified) };
-            var orderChangedEvent = new OrderChangedEvent(changedEntries);
-
-            var sourceInventoryInfos = new[]
+            new object[]
             {
-                new InventoryInfo
+                new GenericChangedEntry<CustomerOrder>(ChangedOrder, InitialOrder, EntryState.Modified),
+                new[]
                 {
-                    ProductId = "shoes",
-                    InStockQuantity = 5
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt",
-                    InStockQuantity = 1
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt-new",
-                    InStockQuantity = 2
-                }
-            };
-            _inventoryServiceMock.Setup(x => x.GetProductsInventoryInfos(It.IsAny<IEnumerable<string>>()))
-                .Returns(sourceInventoryInfos);
-
-            var expectedInventoryInfos = new[]
-            {
-                new InventoryInfo
-                {
-                    ProductId = "shoes",
-                    InStockQuantity = 2 // 3 pieces taken
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt-new",
-                    InStockQuantity = 1 // 1 piece taken
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt",
-                    InStockQuantity = 3 // 2 pieces returned
-                }
-            };
-
-            IEnumerable<InventoryInfo> actualInventoryInfos = null;
-            _inventoryServiceMock.Setup(x => x.UpsertInventories(It.IsAny<IEnumerable<InventoryInfo>>()))
-                .Callback((IEnumerable<InventoryInfo> inventoryInfos) => { actualInventoryInfos = inventoryInfos; });
-
-            // Act
-            _targetHandler.HandleImmediately(orderChangedEvent);
-
-            // Assert
-            Assert.Equal(expectedInventoryInfos, actualInventoryInfos, new InventoryInfoEqualityComparer());
-        }
-
-        [Fact]
-        public void AdjustInventoryHandler_AdjustsInventory_OnOrderCreation()
-        {
-            // Arrange
-            var newOrder = CreateTestOrder("TESTORDER-000001");
-            var changedEntries = new[] { new GenericChangedEntry<CustomerOrder>(newOrder, newOrder, EntryState.Added) };
-            var orderChangedEvent = new OrderChangedEvent(changedEntries);
-
-            var sourceInventoryInfos = new[]
-            {
-                new InventoryInfo
-                {
-                    ProductId = "shoes",
-                    InStockQuantity = 5
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt",
-                    InStockQuantity = 1
-                },
-            };
-            _inventoryServiceMock.Setup(x => x.GetProductsInventoryInfos(It.IsAny<IEnumerable<string>>()))
-                .Returns(sourceInventoryInfos);
-
-            var expectedInventoryInfos = new[]
-            {
-                new InventoryInfo
-                {
-                    ProductId = "shoes",
-                    InStockQuantity = 3 // 2 pieces taken
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt",
-                    InStockQuantity = 0 // 2 pieces taken, InStockQuantity is "stuck" at 0 instead of reaching -1
-                }
-            };
-
-            IEnumerable<InventoryInfo> actualInventoryInfos = null;
-            _inventoryServiceMock.Setup(x => x.UpsertInventories(It.IsAny<IEnumerable<InventoryInfo>>()))
-                .Callback((IEnumerable<InventoryInfo> inventoryInfos) => { actualInventoryInfos = inventoryInfos; });
-
-            // Act
-            _targetHandler.HandleImmediately(orderChangedEvent);
-
-            // Assert
-            Assert.Equal(expectedInventoryInfos, actualInventoryInfos, new InventoryInfoEqualityComparer());
-        }
-
-        [Fact]
-        public void AdjustInventoryHandler_AdjustsInventory_OnOrderDelete()
-        {
-            // Arrange
-            var oldOrder = CreateTestOrder("TESTORDER-000001");
-            var changedEntries = new[] { new GenericChangedEntry<CustomerOrder>(oldOrder, oldOrder, EntryState.Deleted) };
-            var orderChangedEvent = new OrderChangedEvent(changedEntries);
-
-            var sourceInventoryInfos = new[]
-            {
-                new InventoryInfo
-                {
-                    ProductId = "shoes",
-                    InStockQuantity = 3
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt",
-                    InStockQuantity = 0
-                },
-            };
-            _inventoryServiceMock.Setup(x => x.GetProductsInventoryInfos(It.IsAny<IEnumerable<string>>()))
-                .Returns(sourceInventoryInfos);
-
-            var expectedInventoryInfos = new[]
-            {
-                new InventoryInfo
-                {
-                    ProductId = "shoes",
-                    InStockQuantity = 5 // 2 pieces returned
-                },
-                new InventoryInfo
-                {
-                    ProductId = "t-shirt",
-                    InStockQuantity = 2 // 2 pieces returned
-                }
-            };
-
-            IEnumerable<InventoryInfo> actualInventoryInfos = null;
-            _inventoryServiceMock.Setup(x => x.UpsertInventories(It.IsAny<IEnumerable<InventoryInfo>>()))
-                .Callback((IEnumerable<InventoryInfo> inventoryInfos) => { actualInventoryInfos = inventoryInfos; });
-
-            // Act
-            _targetHandler.HandleImmediately(orderChangedEvent);
-
-            // Assert
-            Assert.Equal(expectedInventoryInfos, actualInventoryInfos, new InventoryInfoEqualityComparer());
-        }
-
-        private static CustomerOrder CreateTestOrder(string id)
-        {
-            return new CustomerOrder
-            {
-                Id = id,
-                Currency = "USD",
-                CustomerId = "Test Customer",
-                EmployeeId = "employee",
-                StoreId = "test store",
-                CreatedDate = DateTime.Now,
-                Items = new List<LineItem>
-                {
-                    new LineItem
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
                     {
-                        Id = "{01234567-89ab-cdef-0123-456789abcdef}",
-                        Price = 20,
+                        FulfillmentCenterId = TestFulfillmentCenterId,
                         ProductId = "shoes",
-                        CatalogId = "catalog",
-                        Currency = "USD",
-                        CategoryId = "category",
-                        Name = "shoes",
-                        Quantity = 2,
-                        ShippingMethodCode = "EMS"
+                        QuantityDelta = 3
                     },
-                    new LineItem
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
                     {
-                        Id = "{abcdef01-2345-6789-abcd-ef0123456789}",
-                        Price = 100,
+                        FulfillmentCenterId = TestFulfillmentCenterId,
+                        ProductId = "t-shirt-new",
+                        QuantityDelta = 1
+                    },
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
+                    {
+                        FulfillmentCenterId = TestFulfillmentCenterId,
                         ProductId = "t-shirt",
-                        CatalogId = "catalog",
-                        CategoryId = "category",
-                        Currency = "USD",
-                        Name = "t-shirt",
-                        Quantity = 2,
-                        ShippingMethodCode = "EMS"
+                        QuantityDelta = -2
                     }
                 }
-            };
+            },
+            new object[]
+            {
+                new GenericChangedEntry<CustomerOrder>(InitialOrder, InitialOrder, EntryState.Added),
+                new[]
+                {
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
+                    {
+                        FulfillmentCenterId = TestFulfillmentCenterId,
+                        ProductId = "shoes",
+                        QuantityDelta = 2
+                    },
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
+                    {
+                        FulfillmentCenterId = TestFulfillmentCenterId,
+                        ProductId = "t-shirt",
+                        QuantityDelta = 2
+                    }
+                }
+            },
+            new object[]
+            {
+                new GenericChangedEntry<CustomerOrder>(InitialOrder, InitialOrder, EntryState.Deleted),
+                new[]
+                {
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
+                    {
+                        FulfillmentCenterId = TestFulfillmentCenterId,
+                        ProductId = "shoes",
+                        QuantityDelta = -2
+                    },
+                    new AdjustInventoryOrderChangedEventHandler.ProductInventoryChange
+                    {
+                        FulfillmentCenterId = TestFulfillmentCenterId,
+                        ProductId = "t-shirt",
+                        QuantityDelta = -2
+                    }
+                }
+            }
+        };
+
+        private bool CompareProductInventoryChanges(
+            AdjustInventoryOrderChangedEventHandler.ProductInventoryChange first,
+            AdjustInventoryOrderChangedEventHandler.ProductInventoryChange second)
+        {
+            if (ReferenceEquals(first, second))
+                return true;
+
+            if (first == null || second == null)
+                return false;
+
+            return first.FulfillmentCenterId == second.FulfillmentCenterId &&
+                   first.ProductId == second.ProductId &&
+                   first.QuantityDelta == second.QuantityDelta;
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void AdjustInventoryHandler_GetProductInventoryChanges_ForOrderChanges(GenericChangedEntry<CustomerOrder> orderChangedEntry,
+            IEnumerable<AdjustInventoryOrderChangedEventHandler.ProductInventoryChange> expectedChanges)
+        {
+            // Arrange
+            var inventoryServiceMock = new Mock<IInventoryService>();
+            var settingsManagerMock = new Mock<ISettingsManager>();
+
+            var storeServiceMock = new Mock<IStoreService>();
+            storeServiceMock.Setup(x => x.GetById(TestStoreId))
+                .Returns(new Store { MainFulfillmentCenterId = TestFulfillmentCenterId });
+
+            var targetHandler = new AdjustInventoryOrderChangedEventHandler(inventoryServiceMock.Object,
+                storeServiceMock.Object, settingsManagerMock.Object);
+
+            // Act
+            var actualChanges = targetHandler.GetProductInventoryChangesFor(orderChangedEntry);
+            
+            // Assert
+            var equalityComparer =
+                AnonymousComparer.Create<AdjustInventoryOrderChangedEventHandler.ProductInventoryChange>(
+                    CompareProductInventoryChanges,
+                    change => change.GetHashCode());
+            Assert.Equal(expectedChanges, actualChanges, equalityComparer);
         }
     }
 }

--- a/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
+++ b/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
@@ -126,21 +126,6 @@ namespace VirtoCommerce.OrderModule.Test
             }
         };
 
-        private bool CompareProductInventoryChanges(
-            AdjustInventoryOrderChangedEventHandler.ProductInventoryChange first,
-            AdjustInventoryOrderChangedEventHandler.ProductInventoryChange second)
-        {
-            if (ReferenceEquals(first, second))
-                return true;
-
-            if (first == null || second == null)
-                return false;
-
-            return first.FulfillmentCenterId == second.FulfillmentCenterId &&
-                   first.ProductId == second.ProductId &&
-                   first.QuantityDelta == second.QuantityDelta;
-        }
-
         [Theory]
         [MemberData(nameof(TestData))]
         public void AdjustInventoryHandler_GetProductInventoryChanges_ForOrderChanges(GenericChangedEntry<CustomerOrder> orderChangedEntry,
@@ -161,10 +146,7 @@ namespace VirtoCommerce.OrderModule.Test
             var actualChanges = targetHandler.GetProductInventoryChangesFor(orderChangedEntry);
             
             // Assert
-            var equalityComparer =
-                AnonymousComparer.Create<AdjustInventoryOrderChangedEventHandler.ProductInventoryChange>(
-                    CompareProductInventoryChanges,
-                    change => change.GetHashCode());
+            var equalityComparer = AnonymousComparer.Create((AdjustInventoryOrderChangedEventHandler.ProductInventoryChange x) => $"{x.FulfillmentCenterId} {x.ProductId} {x.QuantityDelta}");
             Assert.Equal(expectedChanges, actualChanges, equalityComparer);
         }
     }

--- a/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
+++ b/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 namespace VirtoCommerce.OrderModule.Test
 {
     [CLSCompliant(false)]
+    [Trait("Category", "CI")]
     public class OrderInventoryAdjustmentTests
     {
         private const string TestStoreId = "TestStore";

--- a/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
+++ b/VirtoCommerce.OrderModule.Test/OrderInventoryAdjustmentTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Moq;
+using VirtoCommerce.Domain.Commerce.Model;
+using VirtoCommerce.Domain.Common.Events;
+using VirtoCommerce.Domain.Inventory.Model;
+using VirtoCommerce.Domain.Inventory.Services;
+using VirtoCommerce.Domain.Order.Events;
+using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.Domain.Store.Services;
+using VirtoCommerce.OrderModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Settings;
+using Xunit;
+
+namespace VirtoCommerce.OrderModule.Test
+{
+    public class OrderInventoryAdjustmentTests
+    {
+        private class InventoryInfoEqualityComparer : IEqualityComparer<InventoryInfo>
+        {
+            public bool Equals(InventoryInfo x, InventoryInfo y)
+            {
+                if (Object.ReferenceEquals(x, y))
+                    return true;
+
+                if (x == null || y == null)
+                    return false;
+
+                return x.ProductId == y.ProductId &&
+                       x.InStockQuantity == y.InStockQuantity;
+            }
+
+            public int GetHashCode(InventoryInfo obj)
+            {
+                return obj.GetHashCode();
+            }
+        }
+
+        private readonly Mock<IInventoryService> _inventoryServiceMock;
+        private readonly Mock<IStoreService> _storeServiceMock;
+        private readonly Mock<ISettingsManager> _settingsManagerMock;
+        private readonly Mock<IBackgroundJobClient> _backgroundJobClientMock;
+        private readonly AdjustInventoryOrderChangedEventHandler _targetHandler;
+
+        public OrderInventoryAdjustmentTests()
+        {
+            _inventoryServiceMock = new Mock<IInventoryService>();
+
+            _storeServiceMock = new Mock<IStoreService>();
+
+            _settingsManagerMock = new Mock<ISettingsManager>();
+            _settingsManagerMock.Setup(x => x.GetValue("Order.AdjustInventory", It.IsAny<bool>()))
+                .Returns(true);
+
+            _backgroundJobClientMock = new Mock<IBackgroundJobClient>();
+
+            _targetHandler = new AdjustInventoryOrderChangedEventHandler(_inventoryServiceMock.Object,
+                _storeServiceMock.Object, _settingsManagerMock.Object, _backgroundJobClientMock.Object);
+
+            // Setting up Hangfire background job client to immediately execute any queued task
+            _backgroundJobClientMock.Setup(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+                .Callback((Job job, IState state) => job.Method.Invoke(_targetHandler, job.Args.ToArray()));
+        }
+
+        [Fact]
+        public async Task AdjustInventoryHandler_AdjustsInventory_OnLineItemQuantityChange()
+        {
+            // Arrange
+            var oldOrder = CreateTestOrder("TESTORDER-000001");
+
+            var newOrder = CreateTestOrder("TESTORDER-000001");
+            var newOrderItems = newOrder.Items.ToList();
+
+            // Adjusting quantity for the first item. This should cause taking 3 pieces of "shoes" from the inventory.
+            newOrderItems[0].Quantity += 3;
+
+            // Changing Id and ProductId for the second item and adjusting its quantity. This will be treated as removal
+            // of "t-shirt" line item and addition of "t-shirt-new" line item, so it should cause the following changes:
+            // - taking 1 piece of "t-shirt-new" from the inventory;
+            // - returning 2 pieces of "t-shirt" to the inventory.
+            newOrderItems[1].Id = "{fedcba98-7654-3210-0123-456789abcdef}";
+            newOrderItems[1].ProductId = "t-shirt-new";
+            newOrderItems[1].Quantity = 1;
+
+            var changedEntries = new[] { new GenericChangedEntry<CustomerOrder>(newOrder, oldOrder, EntryState.Modified) };
+            var orderChangedEvent = new OrderChangedEvent(changedEntries);
+
+            var sourceInventoryInfos = new[]
+            {
+                new InventoryInfo
+                {
+                    ProductId = "shoes",
+                    InStockQuantity = 5
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt",
+                    InStockQuantity = 1
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt-new",
+                    InStockQuantity = 2
+                }
+            };
+            _inventoryServiceMock.Setup(x => x.GetProductsInventoryInfos(It.IsAny<IEnumerable<string>>()))
+                .Returns(sourceInventoryInfos);
+
+            var expectedInventoryInfos = new[]
+            {
+                new InventoryInfo
+                {
+                    ProductId = "shoes",
+                    InStockQuantity = 2 // 3 pieces taken
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt-new",
+                    InStockQuantity = 1 // 1 piece taken
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt",
+                    InStockQuantity = 3 // 2 pieces returned
+                }
+            };
+
+            IEnumerable<InventoryInfo> actualInventoryInfos = null;
+            _inventoryServiceMock.Setup(x => x.UpsertInventories(It.IsAny<IEnumerable<InventoryInfo>>()))
+                .Callback((IEnumerable<InventoryInfo> inventoryInfos) => { actualInventoryInfos = inventoryInfos; });
+
+            // Act
+            await _targetHandler.Handle(orderChangedEvent);
+
+            // Assert
+            Assert.Equal(expectedInventoryInfos, actualInventoryInfos, new InventoryInfoEqualityComparer());
+        }
+
+        [Fact]
+        public async Task AdjustInventoryHandler_AdjustsInventory_OnOrderCreation()
+        {
+            // Arrange
+            var newOrder = CreateTestOrder("TESTORDER-000001");
+            var changedEntries = new[] { new GenericChangedEntry<CustomerOrder>(newOrder, newOrder, EntryState.Added) };
+            var orderChangedEvent = new OrderChangedEvent(changedEntries);
+
+            var sourceInventoryInfos = new[]
+            {
+                new InventoryInfo
+                {
+                    ProductId = "shoes",
+                    InStockQuantity = 5
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt",
+                    InStockQuantity = 1
+                },
+            };
+            _inventoryServiceMock.Setup(x => x.GetProductsInventoryInfos(It.IsAny<IEnumerable<string>>()))
+                .Returns(sourceInventoryInfos);
+
+            var expectedInventoryInfos = new[]
+            {
+                new InventoryInfo
+                {
+                    ProductId = "shoes",
+                    InStockQuantity = 3 // 2 pieces taken
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt",
+                    InStockQuantity = 0 // 2 pieces taken, InStockQuantity is "stuck" at 0 instead of reaching -1
+                }
+            };
+
+            IEnumerable<InventoryInfo> actualInventoryInfos = null;
+            _inventoryServiceMock.Setup(x => x.UpsertInventories(It.IsAny<IEnumerable<InventoryInfo>>()))
+                .Callback((IEnumerable<InventoryInfo> inventoryInfos) => { actualInventoryInfos = inventoryInfos; });
+
+            // Act
+            await _targetHandler.Handle(orderChangedEvent);
+
+            // Assert
+            Assert.Equal(expectedInventoryInfos, actualInventoryInfos, new InventoryInfoEqualityComparer());
+        }
+
+        [Fact]
+        public async Task AdjustInventoryHandler_AdjustsInventory_OnOrderDelete()
+        {
+            // Arrange
+            var oldOrder = CreateTestOrder("TESTORDER-000001");
+            var changedEntries = new[] { new GenericChangedEntry<CustomerOrder>(oldOrder, oldOrder, EntryState.Deleted) };
+            var orderChangedEvent = new OrderChangedEvent(changedEntries);
+
+            var sourceInventoryInfos = new[]
+            {
+                new InventoryInfo
+                {
+                    ProductId = "shoes",
+                    InStockQuantity = 3
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt",
+                    InStockQuantity = 0
+                },
+            };
+            _inventoryServiceMock.Setup(x => x.GetProductsInventoryInfos(It.IsAny<IEnumerable<string>>()))
+                .Returns(sourceInventoryInfos);
+
+            var expectedInventoryInfos = new[]
+            {
+                new InventoryInfo
+                {
+                    ProductId = "shoes",
+                    InStockQuantity = 5 // 2 pieces returned
+                },
+                new InventoryInfo
+                {
+                    ProductId = "t-shirt",
+                    InStockQuantity = 2 // 2 pieces returned
+                }
+            };
+
+            IEnumerable<InventoryInfo> actualInventoryInfos = null;
+            _inventoryServiceMock.Setup(x => x.UpsertInventories(It.IsAny<IEnumerable<InventoryInfo>>()))
+                .Callback((IEnumerable<InventoryInfo> inventoryInfos) => { actualInventoryInfos = inventoryInfos; });
+
+            // Act
+            await _targetHandler.Handle(orderChangedEvent);
+
+            // Assert
+            Assert.Equal(expectedInventoryInfos, actualInventoryInfos, new InventoryInfoEqualityComparer());
+        }
+
+        private static CustomerOrder CreateTestOrder(string id)
+        {
+            return new CustomerOrder
+            {
+                Id = id,
+                Currency = "USD",
+                CustomerId = "Test Customer",
+                EmployeeId = "employee",
+                StoreId = "test store",
+                CreatedDate = DateTime.Now,
+                Items = new List<LineItem>
+                {
+                    new LineItem
+                    {
+                        Id = "{01234567-89ab-cdef-0123-456789abcdef}",
+                        Price = 20,
+                        ProductId = "shoes",
+                        CatalogId = "catalog",
+                        Currency = "USD",
+                        CategoryId = "category",
+                        Name = "shoes",
+                        Quantity = 2,
+                        ShippingMethodCode = "EMS"
+                    },
+                    new LineItem
+                    {
+                        Id = "{abcdef01-2345-6789-abcd-ef0123456789}",
+                        Price = 100,
+                        ProductId = "t-shirt",
+                        CatalogId = "catalog",
+                        CategoryId = "category",
+                        Currency = "USD",
+                        Name = "t-shirt",
+                        Quantity = 2,
+                        ShippingMethodCode = "EMS"
+                    }
+                }
+            };
+        }
+    }
+}

--- a/VirtoCommerce.OrderModule.Test/VirtoCommerce.OrderModule.Test.csproj
+++ b/VirtoCommerce.OrderModule.Test/VirtoCommerce.OrderModule.Test.csproj
@@ -65,6 +65,9 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="Hangfire.Core, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
@@ -74,6 +77,9 @@
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>..\packages\valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net46\StackExchange.Redis.dll</HintPath>
@@ -137,6 +143,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="MigrationScenarios.cs" />
+    <Compile Include="OrderInventoryAdjustmentTests.cs" />
     <Compile Include="OrderTotalsCalculationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CRUDScenarios.cs" />

--- a/VirtoCommerce.OrderModule.Test/VirtoCommerce.OrderModule.Test.csproj
+++ b/VirtoCommerce.OrderModule.Test/VirtoCommerce.OrderModule.Test.csproj
@@ -65,9 +65,6 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="Hangfire.Core, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
@@ -77,9 +74,6 @@
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>..\packages\valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net46\StackExchange.Redis.dll</HintPath>

--- a/VirtoCommerce.OrderModule.Test/packages.config
+++ b/VirtoCommerce.OrderModule.Test/packages.config
@@ -6,12 +6,10 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
-  <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
   <package id="Moq" version="4.8.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />

--- a/VirtoCommerce.OrderModule.Test/packages.config
+++ b/VirtoCommerce.OrderModule.Test/packages.config
@@ -6,10 +6,12 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
   <package id="Moq" version="4.8.2" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />

--- a/VirtoCommerce.OrderModule.Web/Module.cs
+++ b/VirtoCommerce.OrderModule.Web/Module.cs
@@ -1,15 +1,17 @@
-﻿using Microsoft.Practices.Unity;
+using Microsoft.Practices.Unity;
 using System;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Web.Http;
 using VirtoCommerce.CoreModule.Data.Services;
 using VirtoCommerce.Domain.Common;
+using VirtoCommerce.Domain.Inventory.Services;
 using VirtoCommerce.Domain.Order.Events;
 using VirtoCommerce.Domain.Order.Model;
 using VirtoCommerce.Domain.Order.Services;
 using VirtoCommerce.Domain.Payment.Services;
 using VirtoCommerce.Domain.Shipping.Services;
+using VirtoCommerce.Domain.Store.Services;
 using VirtoCommerce.OrderModule.Data.Handlers;
 using VirtoCommerce.OrderModule.Data.Notifications;
 using VirtoCommerce.OrderModule.Data.Repositories;
@@ -54,6 +56,10 @@ namespace VirtoCommerce.OrderModule.Web
 
         public override void Initialize()
         {
+            // Here we explicitly indicate which constructor the Unity container should use to instantiate the AdjustInventoryOrderChangedEventHandler.
+            // Without this, Unity container might choose the constructor for unit tests and fail to create this type.
+            _container.RegisterType<AdjustInventoryOrderChangedEventHandler>(new InjectionConstructor(typeof(IInventoryService), typeof(IStoreService), typeof(ISettingsManager)));
+
             var eventHandlerRegistrar = _container.Resolve<IHandlerRegistrar>();
 
             //Registration welcome email notification.

--- a/VirtoCommerce.OrderModule.Web/Module.cs
+++ b/VirtoCommerce.OrderModule.Web/Module.cs
@@ -56,10 +56,6 @@ namespace VirtoCommerce.OrderModule.Web
 
         public override void Initialize()
         {
-            // Here we explicitly indicate which constructor the Unity container should use to instantiate the AdjustInventoryOrderChangedEventHandler.
-            // Without this, Unity container might choose the constructor for unit tests and fail to create this type.
-            _container.RegisterType<AdjustInventoryOrderChangedEventHandler>(new InjectionConstructor(typeof(IInventoryService), typeof(IStoreService), typeof(ISettingsManager)));
-
             var eventHandlerRegistrar = _container.Resolve<IHandlerRegistrar>();
 
             //Registration welcome email notification.

--- a/VirtoCommerce.OrderModule.Web/module.manifest
+++ b/VirtoCommerce.OrderModule.Web/module.manifest
@@ -122,7 +122,7 @@
               <valueType>boolean</valueType>
               <defaultValue>true</defaultValue>
               <title>Adjust inventory for orders</title>
-              <description>Adjust inventory when order state changed.</description>
+              <description>Adjust inventory when order state or quantity of products in product line item had been changed. WARNING: this setting is intended for demo purposes only, and enabling it may cause unexpected inventory changes!</description>
             </setting>
             <setting>
                 <name>Order.ExportImport.Description</name>

--- a/VirtoCommerce.OrderModule.Web/module.manifest
+++ b/VirtoCommerce.OrderModule.Web/module.manifest
@@ -122,7 +122,7 @@
               <valueType>boolean</valueType>
               <defaultValue>true</defaultValue>
               <title>Adjust inventory for orders</title>
-              <description>Adjust inventory when order state or quantity of products in product line item had been changed. WARNING: this setting is intended for demo purposes only, and enabling it may cause unexpected inventory changes!</description>
+              <description>Adjust inventory when order state or quantity of products in any of order line items had been changed. WARNING: this setting is intended for demo purposes only, and enabling it may cause unexpected inventory changes!</description>
             </setting>
             <setting>
                 <name>Order.ExportImport.Description</name>


### PR DESCRIPTION
Changes made there for #69:
* Added reference to the `Hangfire.Core` for the `VirtoCommerce.OrdersModule.Data` project (to use it for background jobs);
* `AdjustInventoryOrderEventHandler`: inventory adjustment now runs in Hangfire task with disabled concurrency;
* `AdjustInventoryOrderEventHandler.TryAdjustOrderInventory` now takes actual data needed for inventory adjustment: change type, order ID, order shipments and line item lists (old and new one). This was needed because Hangfire with it's default serialization settings can't deserialize `GenericChangedEntry<CustomerOrder>` (because of missing default constructor), nor the `CustomerOrder` itself (because of polymorphic `IOperation` implementations).