### PR TITLE
Fixed bug which prevent override ProductInventoryChange

### DIFF
--- a/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/VirtoCommerce.OrderModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -26,8 +26,7 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
             public string FulfillmentCenterId { get; set; }
             public int QuantityDelta { get; set; }
         }
-
-
+        
         private readonly IInventoryService _inventoryService;
         private readonly ISettingsManager _settingsManager;
         private readonly IStoreService _storeService;
@@ -151,12 +150,12 @@ namespace VirtoCommerce.OrderModule.Data.Handlers
 
                 if (oldQuantity != newQuantity)
                 {
-                    itemChanges.Add(new ProductInventoryChange
-                    {
-                        ProductId = changedItem.ProductId,
-                        QuantityDelta = newQuantity - oldQuantity,
-                        FulfillmentCenterId = GetFullfilmentCenterForLineItem(changedItem, customerOrder.StoreId, customerOrderShipments)
-                    });
+                    var itemChange = AbstractTypeFactory<ProductInventoryChange>.TryCreateInstance();
+                    itemChange.ProductId = changedItem.ProductId;
+                    itemChange.QuantityDelta = newQuantity - oldQuantity;
+                    itemChange.FulfillmentCenterId = GetFullfilmentCenterForLineItem(changedItem, customerOrder.StoreId,
+                        customerOrderShipments);
+                    itemChanges.Add(itemChange);
                 }
             });
             //Do not return unchanged records

--- a/VirtoCommerce.OrderModule.Web/JsonConverters/PolymorphicOperationJsonConverter.cs
+++ b/VirtoCommerce.OrderModule.Web/JsonConverters/PolymorphicOperationJsonConverter.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.Domain.Payment.Model;
 using VirtoCommerce.Domain.Payment.Services;
 using VirtoCommerce.Domain.Shipping.Model;
 using VirtoCommerce.Domain.Shipping.Services;
+using VirtoCommerce.OrderModule.Data.Handlers;
 using VirtoCommerce.OrderModule.Data.Utilities;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -15,7 +16,12 @@ namespace VirtoCommerce.OrderModule.Web.JsonConverters
 {
     public class PolymorphicOperationJsonConverter : JsonConverter
     {
-        private static readonly Type[] _knowTypes = { typeof(IOperation), typeof(LineItem), typeof(CustomerOrderSearchCriteria), typeof(PaymentMethod), typeof(ShippingMethod) };
+        private static readonly Type[] _knowTypes =
+        {
+            typeof(IOperation), typeof(LineItem), typeof(CustomerOrderSearchCriteria),
+            typeof(PaymentMethod), typeof(ShippingMethod),
+            typeof(AdjustInventoryOrderChangedEventHandler.ProductInventoryChange)
+        };
 
         private readonly IPaymentMethodsService _paymentMethodsService;
         private readonly IShippingMethodsService _shippingMethodsService;

--- a/VirtoCommerce.OrderModule.Web/Module.cs
+++ b/VirtoCommerce.OrderModule.Web/Module.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Web.Http;
+using Hangfire.Common;
 using Microsoft.Practices.Unity;
 using VirtoCommerce.CoreModule.Data.Services;
 using VirtoCommerce.Domain.Common;
@@ -168,6 +169,9 @@ namespace VirtoCommerce.OrderModule.Web
             var allOrderKnownTypes = new[] { typeof(Shipment), typeof(PaymentIn), typeof(CustomerOrder) }.Concat(allPaymentMethodTypes).Concat(allShippingmethodTypes).ToArray();
             httpConfiguration.Formatters.XmlFormatter.SetSerializer<CustomerOrder>(new DataContractSerializer(typeof(CustomerOrder), allOrderKnownTypes));
             httpConfiguration.Formatters.XmlFormatter.SetSerializer<CustomerOrderSearchResult>(new DataContractSerializer(typeof(CustomerOrderSearchResult), allOrderKnownTypes));
+
+            // This line refreshes Hangfire JsonConverter with the current JsonSerializerSettings - PolymorphicOperationJsonConverter needs to be included
+            JobHelper.SetSerializerSettings(httpConfiguration.Formatters.JsonFormatter.SerializerSettings);
         }
 
         #endregion


### PR DESCRIPTION
Without that serialize adjust inventory background job fails with "unable to cast" exception if you trying override ProductInventoryChange