### PR TITLE
bug/VP-3496: Add pagination to order history blade

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderHistorySearchCriteria.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderHistorySearchCriteria.cs
@@ -1,0 +1,9 @@
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.OrdersModule.Core.Model.Search
+{
+    public class CustomerOrderHistorySearchCriteria : SearchCriteriaBase
+    {
+        public string OrderId { get; set; }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-change-log.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-change-log.js
@@ -1,16 +1,81 @@
 angular.module('virtoCommerce.orderModule')
-.controller('virtoCommerce.orderModule.customerOrderChangeLogController', ['$scope', 'virtoCommerce.orderModule.order_res_customerOrders', 
-function ($scope, customerOrders) {
+    .controller('virtoCommerce.orderModule.customerOrderChangeLogController', ['$scope', 'virtoCommerce.orderModule.order_res_customerOrders', 'platformWebApp.uiGridHelper', 'platformWebApp.bladeUtils', '$timeout', function ($scope, customerOrders, uiGridHelper, bladeUtils, $timeout) {
+        var blade = $scope.blade;
 
-    customerOrders.getOrderChanges({
-        id: $scope.blade.orderId
-    }, function (data) {
-        $scope.blade.isLoading = false;
-        $scope.blade.currentEntities = data;
-    });
+        //pagination settings
+        $scope.pageSettings = {};
+        $scope.pageSettings.currentPage = 1;
+        $scope.pageSettings.itemsPerPageCount = 20;
+        $scope.pageSettings.totalItems = 0;
 
-    // ui-grid
-    $scope.setGridOptions = function (gridOptions) {
-        $scope.gridOptions = gridOptions;
-    };
+        blade.refresh = function () {
+            blade.isLoading = true;
+
+            if ($scope.pageSettings.currentPage !== 1) {
+                $scope.pageSettings.currentPage = 1;
+            }
+
+            customerOrders.searchOrderChanges(getSearchCriteria(), (data) => {
+                blade.isLoading = false;
+                $scope.pageSettings.totalItems = data.totalCount;
+                blade.currentEntities = data.results;
+                $scope.hasMore = data.results.length === $scope.pageSettings.itemsPerPageCount;
+
+                if ($scope.gridApi) {
+                    $scope.gridApi.infiniteScroll.resetScroll(true, true);
+                    $scope.gridApi.infiniteScroll.dataLoaded();
+                }
+            });
+        };
+
+        function showMore() {
+            if ($scope.hasMore) {
+                ++$scope.pageSettings.currentPage;
+                $scope.gridApi.infiniteScroll.saveScrollPercentage();
+                blade.isLoading = true;
+
+                customerOrders.searchOrderChanges(getSearchCriteria(), (data) => {
+                    blade.isLoading = false;
+                    $scope.pageSettings.totalItems = data.totalCount;
+                    blade.currentEntities = blade.currentEntities.concat(data.results);
+                    $scope.hasMore = data.results.length === $scope.pageSettings.itemsPerPageCount;
+                    $scope.gridApi.infiniteScroll.dataLoaded();
+                });
+            }
+        }
+
+        function getSearchCriteria() {
+            return {
+                orderId: blade.orderId,
+                sort: uiGridHelper.getSortExpression($scope),
+                skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
+                take: $scope.pageSettings.itemsPerPageCount
+            };
+        }
+
+        var filter = blade.filter = $scope.filter = {};
+        filter.criteriaChanged = function () {
+            if ($scope.pageSettings.currentPage > 1) {
+                $scope.pageSettings.currentPage = 1;
+            } else {
+                blade.refresh();
+            }
+        };
+
+        // ui-grid
+        $scope.setGridOptions = function (gridOptions) {
+            bladeUtils.initializePagination($scope, true);
+
+            uiGridHelper.initialize($scope, gridOptions, function (gridApi) {
+                //update gridApi for current grid
+                $scope.gridApi = gridApi;
+                uiGridHelper.bindRefreshOnSortChanged($scope);
+                $scope.gridApi.infiniteScroll.on.needLoadMoreData($scope, showMore);
+
+            });
+
+            $timeout(function () { blade.refresh(); });
+        };
+
+        blade.refresh();
 }]);

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-change-log.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-change-log.tpl.html
@@ -1,14 +1,22 @@
+<div class="blade-static">
+    <div class="form-group">
+        <p class="form-count">{{'platform.list.count' | translate}}: <span class="count">{{pageSettings.totalItems | number:0}}</span></p>
+    </div>
+</div>
+
 <div class="blade-content __large-wide">
     <div class="blade-inner">
         <div class="inner-block">
             <div class="table-wrapper" ng-init="setGridOptions({
                 data: 'blade.currentEntities',
+                infiniteScrollRowsFromEnd: 10,
+                useExternalSorting: true,
                 columnDefs: [
                     { name: 'createdBy', displayName: 'platform.blades.operation-list.labels.login', width: 100 },
                     { name: 'detail', displayName: 'platform.blades.operation-list.labels.details' },
                     { name: 'createdDate', displayName: 'platform.blades.operation-list.labels.time', width: 87 }
                 ]})">
-                <div ng-if="blade.currentEntities.length" ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-resize-columns ui-grid-move-columns ui-grid-pinning ui-grid-height></div>
+                <div ng-if="blade.currentEntities.length" ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-resize-columns ui-grid-move-columns ui-grid-pinning ui-grid-height ui-grid-infinite-scroll></div>
             </div>
             <div class="note" ng-if="!blade.currentEntities.length">{{ 'platform.list.no-data' | translate }}</div>
         </div>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/resources/customerOrders.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/resources/customerOrders.js
@@ -7,6 +7,7 @@ angular.module('virtoCommerce.orderModule')
         recalculate: { method: 'PUT', url: 'api/order/customerOrders/recalculate' },
         update: { method: 'PUT', url: 'api/order/customerOrders' },
         getDashboardStatistics: { url: 'api/order/dashboardStatistics' },
-        getOrderChanges: { method: 'GET', url: 'api/order/customerOrders/:id/changes', isArray: true }
+        getOrderChanges: { method: 'GET', url: 'api/order/customerOrders/:id/changes', isArray: true },
+        searchOrderChanges: { method: 'POST', url: 'api/order/customerOrders/searchChanges'}
     });
 }]);

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/widgets/customerOrder-change-log-widget.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/widgets/customerOrder-change-log-widget.js
@@ -8,6 +8,7 @@ angular.module('virtoCommerce.orderModule')
                 orderId: blade.customerOrder.id,
                 headIcon: blade.headIcon,
                 title: blade.title,
+                titleValues: { customer: blade.customerOrder.customerName },
                 subtitle: 'platform.widgets.operations.blade-subtitle',
                 isExpandable: true,
                 controller: 'virtoCommerce.orderModule.customerOrderChangeLogController',


### PR DESCRIPTION
VP-3496: Add pagination to order changes blade
* Add method to a controller to search order changes
* Add infinite scrolling to order changes blade

### Problem
Can't see more than 20 items in order changes blade 

### Solution
 Add pagination to order history blade

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
