### PR TITLE
VP-6698: Fix inventory product amount after order has been created

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -105,12 +105,9 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
 
             var itemChanges = new List<ProductInventoryChange>();
 
-
             var inventoryInfos = (await _inventoryService.GetProductsInventoryInfosAsync(newLineItems.Select(x=>x.ProductId))).ToList();
             var store = await _storeService.GetByIdAsync(customerOrder.StoreId, StoreResponseGroup.StoreFulfillmentCenters.ToString());
 
-
-            // The action should start synchronously. If make the action async it is run after itemChanges returned from this function 
             newLineItems.CompareTo(oldLineItems, EqualityComparer<LineItem>.Default,  (state, changedItem, originalItem) =>
             {
                 var newQuantity = changedItem.Quantity;
@@ -130,7 +127,7 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                     var itemChange = AbstractTypeFactory<ProductInventoryChange>.TryCreateInstance();
                     itemChange.ProductId = changedItem.ProductId;
                     itemChange.QuantityDelta = newQuantity - oldQuantity;
-                    itemChange.FulfillmentCenterId = GetFullfilmentCenterForLineItemAsync(changedItem, customerOrderShipments, inventoryInfos, store);
+                    itemChange.FulfillmentCenterId = GetFullfilmentCenterForLineItem(changedItem, customerOrderShipments, inventoryInfos, store);
                     itemChanges.Add(itemChange);
                 }
             });
@@ -221,7 +218,7 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
             var inventoryInfos = inventories.ToList();
             var store = await _storeService.GetByIdAsync(order.StoreId, StoreResponseGroup.StoreFulfillmentCenters.ToString());
 
-            var fulfillmentCenterId = GetFullfilmentCenterForLineItemAsync(origLineItem,  order.Shipments?.ToArray(), inventoryInfos, store);
+            var fulfillmentCenterId = GetFullfilmentCenterForLineItem(origLineItem,  order.Shipments?.ToArray(), inventoryInfos, store);
             var inventoryInfo = inventoryInfos.Where(x => x.FulfillmentCenterId == (fulfillmentCenterId ?? x.FulfillmentCenterId))
                 .FirstOrDefault(x => x.ProductId.EqualsInvariant(origLineItem.ProductId));
             if (inventoryInfo != null)
@@ -258,7 +255,7 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
         /// <param name="inventoryInfos"></param>
         /// <param name="store"></param>
         /// <returns></returns>
-        protected virtual string GetFullfilmentCenterForLineItemAsync(LineItem lineItem, Shipment[] orderShipments, List<InventoryInfo> inventoryInfos, Store store)
+        protected virtual string GetFullfilmentCenterForLineItem(LineItem lineItem, Shipment[] orderShipments, List<InventoryInfo> inventoryInfos, Store store)
         {
             if (lineItem == null)
             {

--- a/tests/VirtoCommerce.OrdersModule.Tests/OrderInventoryAdjustmentTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/OrderInventoryAdjustmentTests.cs
@@ -16,7 +16,6 @@ using VirtoCommerce.InventoryModule.Core.Model;
 using System;
 using System.Linq;
 using FluentAssertions;
-using VirtoCommerce.InventoryModule.Core.Model.Search;
 
 namespace VirtoCommerce.OrdersModule.Tests
 {
@@ -155,7 +154,7 @@ namespace VirtoCommerce.OrdersModule.Tests
                 storeServiceMock.Object, settingsManagerMock.Object, itemServiceMock.Object);
 
             // Act
-            var actualChanges = await targetHandler.GetProductInventoryChangesFor(orderChangedEntry);
+            var actualChanges = targetHandler.GetProductInventoryChangesFor(orderChangedEntry);
 
             // Assert
             var equalityComparer = AnonymousComparer.Create((ProductInventoryChange x) => $"{x.FulfillmentCenterId} {x.ProductId} {x.QuantityDelta}");
@@ -237,7 +236,7 @@ namespace VirtoCommerce.OrdersModule.Tests
                 storeServiceMock.Object, settingsManagerMock.Object, itemServiceMock.Object);
 
             // Act
-            var actualChanges = await targetHandler.GetProductInventoryChangesFor(changedEntry);
+            var actualChanges = targetHandler.GetProductInventoryChangesFor(changedEntry);
 
             // Assert
             actualChanges.Should().HaveCount(1);

--- a/tests/VirtoCommerce.OrdersModule.Tests/OrderInventoryAdjustmentTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/OrderInventoryAdjustmentTests.cs
@@ -154,7 +154,7 @@ namespace VirtoCommerce.OrdersModule.Tests
                 storeServiceMock.Object, settingsManagerMock.Object, itemServiceMock.Object);
 
             // Act
-            var actualChanges = targetHandler.GetProductInventoryChangesFor(orderChangedEntry);
+            var actualChanges =  await targetHandler.GetProductInventoryChangesFor(orderChangedEntry);
 
             // Assert
             var equalityComparer = AnonymousComparer.Create((ProductInventoryChange x) => $"{x.FulfillmentCenterId} {x.ProductId} {x.QuantityDelta}");
@@ -236,7 +236,7 @@ namespace VirtoCommerce.OrdersModule.Tests
                 storeServiceMock.Object, settingsManagerMock.Object, itemServiceMock.Object);
 
             // Act
-            var actualChanges = targetHandler.GetProductInventoryChangesFor(changedEntry);
+            var actualChanges = await targetHandler.GetProductInventoryChangesFor(changedEntry);
 
             // Assert
             actualChanges.Should().HaveCount(1);


### PR DESCRIPTION
### Related task:     
VP-6698 Product's "In stock" amount not changing after order
### Problem:
When setting "Adjust inventory for orders" is enabled and user create order then "in stock" amount of that product not changing
### Changes:
Run CompareTo action synchronously