### PR TITLE
HDOT-4184 Add logging for order creation and deletion

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/LogChangesOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/LogChangesOrderChangedEventHandler.cs
@@ -131,11 +131,11 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
             }
             else if (changedEntry.EntryState == EntryState.Deleted)
             {
-                result.Add($"The {changedEntry.NewEntry.OperationType} {changedEntry.NewEntry.Number} deleted");
+                result.Add($"The {changedEntry.NewEntry.OperationType} {changedEntry.NewEntry.Number} has been deleted");
             }
             else if (changedEntry.EntryState == EntryState.Added)
             {
-                result.Add($"The new {changedEntry.NewEntry.OperationType} {changedEntry.NewEntry.Number} added");
+                result.Add($"The new {changedEntry.NewEntry.OperationType} {changedEntry.NewEntry.Number} has been created");
             }
             return result.Select(x => GetLogRecord(changedEntry.NewEntry, x));
         }

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/LogChangesOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/LogChangesOrderChangedEventHandler.cs
@@ -110,9 +110,8 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                     diff.AddRange(Comparer.Compare(order, changedEntry.NewEntry as CustomerOrder));
                 }
 
-                List<string> auditableProperties;
                 var type = changedEntry.OldEntry.GetType();
-                if (!_auditablePropertiesListByTypeDict.TryGetValue(type.Name, out auditableProperties))
+                if (!_auditablePropertiesListByTypeDict.TryGetValue(type.Name, out var auditableProperties))
                 {
                     auditableProperties = type.GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(AuditableAttribute)))
                                                               .Select(x => x.Name)
@@ -137,6 +136,7 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
             {
                 result.Add($"The new {changedEntry.NewEntry.OperationType} {changedEntry.NewEntry.Number} has been created");
             }
+
             return result.Select(x => GetLogRecord(changedEntry.NewEntry, x));
         }
 
@@ -210,9 +210,8 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
             result.ObjectType = operation.GetType().Name;
             result.OperationType = EntryState.Modified;
             result.Detail = template;
-            
-            return result;
 
+            return result;
         }
     }
 


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/HDOT-4184

This PR changes the behavior of the `LogChangesOrderChangedEventHandler`. Previously, this handler was logging only changes of existing order. This behavior had been added in the [very first commit adding this handler](https://github.com/VirtoCommerce/vc-module-order/commit/376edb0291f5e5de7ea383b6258ea2e867517b4a#diff-1c68d0e233311cf3eb8c6bd1cbc556794af73206ff571508341724489efd3264R44), and it [existed in observers even before that commit](https://github.com/VirtoCommerce/vc-module-order/commit/376edb0291f5e5de7ea383b6258ea2e867517b4a#diff-7795fa2f65ecc1ff9700b41bbcc1c76ad85cec578ef506b407c5ab71c42c399eL57). However, this approach did not log order creation and deletion - so, if the order gets removed for some reason, there is no way to know if it was removed using VirtoCommerce and, if it was, who did that and when it happened. This PR attempts to change this behavior by introducing the following changes:
1. First and most important, this PR handles order change entries that reflect order creation and deletion. It reuses the existing code for detecting and generating order changes, but it changes the way of filling original and modified operations used for comparison:
    * If the order had been modified, the behavior won't change - `originalOperations` will contain operations from `OldEntry`, and `modifiedOperations` will contain operations from `NewEntry`, so the code will compare these two lists and generate a list of changes;
    * If the order had been created, `originalOperations` will be empty, so all the operations from the created order will be marked as created (this includes order and all of its shipments and payments);
    * If the order had been deleted, `modifiedOperations` will be empty, so all the operations from the deleted order will be marked as deleted.
2. Since the code that generates a flat list of order operations from the order had been repetitive, I've extracted it into a separate method to reduce the code duplication.
3. I've also changed log messages for created/deleted operations for clarity - messages like `The CustomerOrder CO210712-00001 deleted` do not seem grammatically correct to me.
Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.35.0-pr-252.zip