### PR TITLE
PT-2572: Remove obsolete CustomerOrders member from orders search result

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderSearchResult.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderSearchResult.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.OrdersModule.Core.Model.Search


### PR DESCRIPTION
## Description
Remove obsolete CustomerOrders member from orders search result
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-2572
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.47.0-pr-273.zip
