### PR TITLE
PT-5934: The "FeeTotal" and "FeeTotalWithTax" fields are calculated correctly

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
@@ -51,6 +51,8 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             retVal.TaxPercentRate = cart.TaxPercentRate;
             retVal.TaxType = cart.TaxType;
             retVal.LanguageCode = cart.LanguageCode;
+            retVal.Fee = cart.Fee;
+            retVal.FeeTotal = cart.FeeTotal;
 
             retVal.Status = "New";
 
@@ -161,6 +163,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             retVal.Width = lineItem.Width;
             retVal.FulfillmentCenterId = lineItem.FulfillmentCenterId;
             retVal.FulfillmentCenterName = lineItem.FulfillmentCenterName;
+            retVal.Fee = lineItem.Fee;
 
             retVal.DiscountAmount = lineItem.DiscountAmount;
             retVal.Price = lineItem.ListPrice;

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -59,7 +59,8 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
             order.DiscountTotal = 0m;
             order.DiscountTotalWithTax = 0m;
-            order.FeeTotal = order.Fee;
+            if(order.Fee != 0)
+                order.FeeTotal = order.Fee;
             order.TaxTotal = 0m;
 
             order.SubTotal = 0m;

--- a/tests/VirtoCommerce.OrdersModule.Tests/CustomerOrderBuilderUnitTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/CustomerOrderBuilderUnitTests.cs
@@ -101,7 +101,7 @@ namespace VirtoCommerce.OrdersModule.Tests
                                  .Excluding(x => x.Fee)
                                  );
             Assert.Equal(cartItem1.ListPrice, orderItem.Price);
-            Assert.Equal(0m, orderItem.Fee);
+            Assert.Equal(0.33m, orderItem.Fee);
         }
 
 

--- a/tests/VirtoCommerce.OrdersModule.Tests/OrderTotalsCalculationTest.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/OrderTotalsCalculationTest.cs
@@ -60,7 +60,7 @@ namespace VirtoCommerce.OrdersModule.Tests
             order.InPayments.Clear();
             totalsCalculator.CalculateTotals(order);
 
-            Assert.Equal(0m, order.Total);
+            Assert.Equal(0.53m, order.Total);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Order: the "fee" and "feeWithTax" fields are zero
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-5934
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.49.0-pr-277.zip
