### PR TITLE
DL-60: Remove pricing dependency

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.js
@@ -1,5 +1,5 @@
 angular.module('virtoCommerce.orderModule')
-    .controller('virtoCommerce.orderModule.customerOrderItemsController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.orderModule.catalogItems', 'virtoCommerce.pricingModule.prices', '$translate', 'platformWebApp.authService', function ($scope, bladeNavigationService, items, prices, $translate, authService) {
+    .controller('virtoCommerce.orderModule.customerOrderItemsController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.orderModule.catalogItems', 'virtoCommerce.orderModule.prices', '$translate', 'platformWebApp.authService', function ($scope, bladeNavigationService, items, prices, $translate, authService) {
     var blade = $scope.blade;
     blade.updatePermission = 'order:update';
     blade.isVisiblePrices = authService.checkPermission('order:read_prices');
@@ -38,6 +38,27 @@ angular.module('virtoCommerce.orderModule')
                     };
                     blade.currentEntity.items.push(newLineItem);
                     blade.recalculateFn();
+                }, function (error) {
+                    if (error.status == 404) {
+                        // Seems no pricing module installed.
+                        // Just add lineitem with zero price.
+                        var newLineItem =
+                        {
+                            productId: data.id,
+                            catalogId: data.catalogId,
+                            categoryId: data.categoryId,
+                            name: data.name,
+                            imageUrl: data.imgSrc,
+                            sku: data.code,
+                            quantity: 1,
+                            price: 0,
+                            discountAmount: 0,
+                            currency: blade.currentEntity.currency
+                        };
+                        blade.currentEntity.items.push(newLineItem);
+                        blade.recalculateFn();
+                    }
+                    
                 });
             });
         });

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/resources/accessToPricing.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/resources/accessToPricing.js
@@ -1,0 +1,7 @@
+angular.module('virtoCommerce.orderModule')
+    .factory('virtoCommerce.orderModule.prices', ['$resource', function ($resource) {
+        return $resource('api/products/:id/prices', { id: '@Id', catalogId: '@catalogId' }, {
+            search: { url: 'api/catalog/products/prices/search' },
+            getProductPrices: { isArray: true }
+        });
+    }]);

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -1,1 +1,37 @@
-﻿<?xml version="1.0" encoding="utf-8"?><module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><id>VirtoCommerce.Orders</id><version>3.203.0</version><version-tag /><platformVersion>3.200.0</platformVersion><title>Orders module</title><description>Document based flexible orders management system</description><authors><author>Virto Commerce</author></authors><owners><owner>Virto Commerce</owner></owners><projectUrl>https://virtocommerce.com/apps/extensions/virto-orders-module</projectUrl><iconUrl>Modules/$(VirtoCommerce.Orders)/Content/logo.png</iconUrl><requireLicenseAcceptance>false</requireLicenseAcceptance><copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright><tags>order system</tags><assemblyFile>VirtoCommerce.OrdersModule.Web.dll</assemblyFile><moduleType>VirtoCommerce.OrdersModule.Web.Module, VirtoCommerce.OrdersModule.Web</moduleType><dependencies><dependency id="VirtoCommerce.Core" version="3.200.0" /><dependency id="VirtoCommerce.Pricing" version="3.200.0" /><dependency id="VirtoCommerce.Customer" version="3.200.0" /><dependency id="VirtoCommerce.Store" version="3.200.0" /><dependency id="VirtoCommerce.Payment" version="3.200.0" /><dependency id="VirtoCommerce.Shipping" version="3.200.0" /><dependency id="VirtoCommerce.Notifications" version="3.200.0" /><dependency id="VirtoCommerce.Cart" version="3.200.0" /><dependency id="VirtoCommerce.Inventory" version="3.200.0" /><dependency id="VirtoCommerce.Search" version="3.202.0" /></dependencies><groups><group>commerce</group></groups><useFullTypeNameInSwagger>false</useFullTypeNameInSwagger></module>
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <id>VirtoCommerce.Orders</id>
+   <version>3.203.0</version>
+   <version-tag />
+   <platformVersion>3.200.0</platformVersion>
+   <title>Orders module</title>
+   <description>Document based flexible orders management system</description>
+   <authors>
+      <author>Virto Commerce</author>
+   </authors>
+   <owners>
+      <owner>Virto Commerce</owner>
+   </owners>
+   <projectUrl>https://virtocommerce.com/apps/extensions/virto-orders-module</projectUrl>
+   <iconUrl>Modules/$(VirtoCommerce.Orders)/Content/logo.png</iconUrl>
+   <requireLicenseAcceptance>false</requireLicenseAcceptance>
+   <copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright>
+   <tags>order system</tags>
+   <assemblyFile>VirtoCommerce.OrdersModule.Web.dll</assemblyFile>
+   <moduleType>VirtoCommerce.OrdersModule.Web.Module, VirtoCommerce.OrdersModule.Web</moduleType>
+   <dependencies>
+      <dependency id="VirtoCommerce.Core" version="3.200.0" />
+      <dependency id="VirtoCommerce.Customer" version="3.200.0" />
+      <dependency id="VirtoCommerce.Store" version="3.200.0" />
+      <dependency id="VirtoCommerce.Payment" version="3.200.0" />
+      <dependency id="VirtoCommerce.Shipping" version="3.200.0" />
+      <dependency id="VirtoCommerce.Notifications" version="3.200.0" />
+      <dependency id="VirtoCommerce.Cart" version="3.200.0" />
+      <dependency id="VirtoCommerce.Inventory" version="3.200.0" />
+      <dependency id="VirtoCommerce.Search" version="3.202.0" />
+   </dependencies>
+   <groups>
+      <group>commerce</group>
+   </groups>
+   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
+</module>


### PR DESCRIPTION
## Description
This contribution inspired by performing devlab issue DL-60.
Dependency on the pricing module removed.
If there is no pricing module installed, lineitems added thru admin UI with zero prices.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/DL-60
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.203.0-pr-286.zip
