### PR TITLE
PT-11555: Removed Obsolete attributes

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrder.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrder.cs
@@ -11,25 +11,49 @@ namespace VirtoCommerce.OrdersModule.Core.Model
 {
     public class CustomerOrder : OrderOperation, IHasTaxDetalization, ISupportSecurityScopes, ITaxable, IHasLanguage, IHasDiscounts, ICloneable, IHasFeesDetalization
     {
+        ///<summary>
+        /// Represents the unique identifier of the customer who placed the order.
+        ///</summary>
         public string CustomerId { get; set; }
 
+        ///<summary>
+        /// Represents the name of the customer who placed the order.
+        ///</summary>
         public string CustomerName { get; set; }
 
-        [Obsolete("Use StoreId instead")]
+        ///<summary>
+        /// It may have been used to indicate the optional channel through which the order was placed, such as a physical store, online store, or mobile app.
+        ///</summary>
         public string ChannelId { get; set; }
 
+        ///<summary>
+        /// Represents the unique identifier of the store where the order was placed, which could be a physical store, online store, or mobile app.
+        ///</summary>
         public string StoreId { get; set; }
 
+        ///<summary>
+        /// Represents the unique identifier of the store where the order was placed, which could be a physical store, online store, or mobile app.
+        ///</summary>
         public string StoreName { get; set; }
 
+        ///<summary>
+        /// Represents the unique identifier of the organization that owns the store where the order was placed.
+        ///</summary>
         public string OrganizationId { get; set; }
 
+        ///<summary>
+        /// Represents the name of the organization that owns the store where the order was placed.
+        ///</summary>
         public string OrganizationName { get; set; }
 
-        [Obsolete("Use CustomerId instead")]
+        ///<summary>
+        /// Represents the name of the organization that owns the store where the order was placed.
+        /// </summary>
         public string EmployeeId { get; set; }
 
-        [Obsolete("Use CustomerName instead")]
+        ///<summary>
+        /// Represents the name of the employee who processed the order.
+        /// </summary>
         public string EmployeeName { get; set; }
 
         /// <summary>

--- a/src/VirtoCommerce.OrdersModule.Core/Services/ICustomerOrderSearchService.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Services/ICustomerOrderSearchService.cs
@@ -10,7 +10,6 @@ namespace VirtoCommerce.OrdersModule.Core.Services
     /// </summary>
     public interface ICustomerOrderSearchService
     {
-        [Obsolete(@"Need to remove after inherit ICustomerOrderSearchService from SearchService<CustomerOrder>")]
         Task<CustomerOrderSearchResult> SearchCustomerOrdersAsync(CustomerOrderSearchCriteria criteria);
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Core/Services/ICustomerOrderService.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Services/ICustomerOrderService.cs
@@ -6,9 +6,7 @@ namespace VirtoCommerce.OrdersModule.Core.Services
 {
     public interface ICustomerOrderService
     {
-        [Obsolete(@"Need to remove after inherit ICustomerOrderService from ICrudService<CustomerOrder>")]
         Task<CustomerOrder[]> GetByIdsAsync(string[] orderIds, string responseGroup = null);
-        [Obsolete(@"Need to remove after inherit ICustomerOrderService from ICrudService<CustomerOrder>")]
         Task<CustomerOrder> GetByIdAsync(string orderId, string responseGroup = null);
         Task SaveChangesAsync(CustomerOrder[] orders);
         Task DeleteAsync(string[] ids);

--- a/src/VirtoCommerce.OrdersModule.Core/Services/IPaymentSearchService.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Services/IPaymentSearchService.cs
@@ -10,7 +10,6 @@ namespace VirtoCommerce.OrdersModule.Core.Services
     /// </summary>
     public interface IPaymentSearchService
     {
-        [Obsolete(@"Need to remove after inherit IPaymentSearchService from SearchService<PaymentIn>")]
         Task<PaymentSearchResult> SearchPaymentsAsync(PaymentSearchCriteria criteria);
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Core/Services/IPaymentService.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Services/IPaymentService.cs
@@ -6,9 +6,7 @@ namespace VirtoCommerce.OrdersModule.Core.Services
 {
     public interface IPaymentService
     {
-        [Obsolete(@"Need to remove after inherit IPaymentService from ICrudService<PaymentIn>")]
         Task<PaymentIn[]> GetByIdsAsync(string[] ids, string responseGroup = null);
-        [Obsolete(@"Need to remove after inherit IPaymentService from ICrudService<PaymentIn>")]
         Task<PaymentIn> GetByIdAsync(string ids, string responseGroup = null);
         Task SaveChangesAsync(PaymentIn[] payments);
         Task DeleteAsync(string[] ids);


### PR DESCRIPTION
## Description
fix: Removed Obsolete attributes for some method to prevent from son)ar warning.
fix: Removed protected virtual async Task  ryAdjustOrderInventory(GenericChangedEntry<CustomerOrder> changedEntry).
feat: Update documentation for some methods.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-11555
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.227.0-pr-333-06b9.zip
