### PR TITLE
PT-12311: Incorrect work with order, when 2 users try to update one order

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrder.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrder.cs
@@ -11,11 +11,12 @@ namespace VirtoCommerce.OrdersModule.Core.Model
 {
     public class CustomerOrder : OrderOperation, IHasTaxDetalization, ISupportSecurityScopes, ITaxable, IHasLanguage, IHasDiscounts, ICloneable, IHasFeesDetalization
     {
+        public byte[] RowVersion { get; set; }
+
         public string CustomerId { get; set; }
 
         public string CustomerName { get; set; }
 
-        [Obsolete("Use StoreId instead")]
         public string ChannelId { get; set; }
 
         public string StoreId { get; set; }
@@ -26,10 +27,8 @@ namespace VirtoCommerce.OrdersModule.Core.Model
 
         public string OrganizationName { get; set; }
 
-        [Obsolete("Use CustomerId instead")]
         public string EmployeeId { get; set; }
 
-        [Obsolete("Use CustomerName instead")]
         public string EmployeeName { get; set; }
 
         /// <summary>

--- a/src/VirtoCommerce.OrdersModule.Data/Model/CustomerOrderEntity.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Model/CustomerOrderEntity.cs
@@ -128,6 +128,7 @@ namespace VirtoCommerce.OrdersModule.Data.Model
                 throw new ArgumentException(@"operation argument must be of type CustomerOrder", nameof(operation));
             }
 
+            order.RowVersion = RowVersion;
             order.ShoppingCartId = ShoppingCartId;
             order.CustomerId = CustomerId;
             order.CustomerName = CustomerName;
@@ -207,6 +208,7 @@ namespace VirtoCommerce.OrdersModule.Data.Model
 
             base.FromModel(order, pkMap);
 
+            RowVersion = order.RowVersion;
             ShoppingCartId = order.ShoppingCartId;
             CustomerId = order.CustomerId;
             CustomerName = order.CustomerName;
@@ -318,6 +320,7 @@ namespace VirtoCommerce.OrdersModule.Data.Model
                     nameof(target));
             }
 
+            operation.RowVersion = RowVersion;
             operation.ShoppingCartId = ShoppingCartId;
             operation.CustomerId = CustomerId;
             operation.CustomerName = CustomerName;

--- a/src/VirtoCommerce.OrdersModule.Data/Repositories/IOrderRepository.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Repositories/IOrderRepository.cs
@@ -18,5 +18,12 @@ namespace VirtoCommerce.OrdersModule.Data.Repositories
         Task<ShipmentEntity[]> GetShipmentsByIdsAsync(string[] ids);
 
         Task RemoveOrdersByIdsAsync(string[] ids);
+
+        /// <summary>
+        /// Patch RowVersion to throw DBConcurrencyException exception if someone updated order before.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="rowVersion"></param>
+        void PatchRowVersion(CustomerOrderEntity entity, byte[] rowVersion);
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Repositories/OrderRepository.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Repositories/OrderRepository.cs
@@ -232,7 +232,7 @@ namespace VirtoCommerce.OrdersModule.Data.Repositories
         {
             if (rowVersion != null)
             {
-                base.DbContext.Entry(entity).Property(e => e.RowVersion).OriginalValue = rowVersion;
+                DbContext.Entry(entity).Property(e => e.RowVersion).OriginalValue = rowVersion;
             }
         }
 

--- a/src/VirtoCommerce.OrdersModule.Data/Repositories/OrderRepository.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Repositories/OrderRepository.cs
@@ -228,6 +228,11 @@ namespace VirtoCommerce.OrdersModule.Data.Repositories
             return result;
         }
 
+        public void PatchRowVersion(CustomerOrderEntity entity, byte[] rowVersion)
+        {
+            base.DbContext.Entry(entity).Property(e => e.RowVersion).OriginalValue = rowVersion;
+        }
+
         public virtual async Task RemoveOrdersByIdsAsync(string[] ids)
         {
             var orders = await GetCustomerOrdersByIdsAsync(ids);

--- a/src/VirtoCommerce.OrdersModule.Data/Repositories/OrderRepository.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Repositories/OrderRepository.cs
@@ -230,7 +230,10 @@ namespace VirtoCommerce.OrdersModule.Data.Repositories
 
         public void PatchRowVersion(CustomerOrderEntity entity, byte[] rowVersion)
         {
-            base.DbContext.Entry(entity).Property(e => e.RowVersion).OriginalValue = rowVersion;
+            if (rowVersion != null)
+            {
+                base.DbContext.Entry(entity).Property(e => e.RowVersion).OriginalValue = rowVersion;
+            }
         }
 
         public virtual async Task RemoveOrdersByIdsAsync(string[] ids)

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderService.cs
@@ -157,35 +157,6 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             await _eventPublisher.Publish(new OrderChangedEvent(changedEntries));
         }
 
-        /// <summary>
-        /// Checks that the order has been modified by another employee before the update operation.
-        /// If returns true, throws an InvalidOperationException with a human-readable message
-        /// indicating who modified the order and advising the user to reload the latest data and retry the operation.
-        /// </summary>
-        /// <param name="modifiedOrder"></param>
-        /// <param name="originalOrder"></param>
-        /// <returns></returns>
-        protected virtual bool HasOrderModified(CustomerOrder modifiedOrder, CustomerOrderEntity originalOrder)
-        {
-            return modifiedOrder.RowVersion != null &&
-                !ByteArrayEquals(modifiedOrder.RowVersion, originalOrder.RowVersion);
-        }
-
-        private bool ByteArrayEquals(byte[] array1, byte[] array2)
-        {
-            if (array1 == null && array2 == null)
-            {
-                return true;
-            }
-
-            if (array1 == null || array2 == null || array1.Length != array2.Length)
-            {
-                return false;
-            }
-
-            return array1.SequenceEqual(array2);
-        }
-
         public virtual async Task DeleteAsync(string[] ids)
         {
             var orders = await GetByIdsAsync(ids, CustomerOrderResponseGroup.Full.ToString());

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -125,18 +124,16 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                     }
                 }
 
-
-
-
                 //Raise domain events
                 await _eventPublisher.Publish(new OrderChangeEvent(changedEntries));
+
                 try
                 {
                     await repository.UnitOfWork.CommitAsync();
                 }
-                catch (DbUpdateConcurrencyException)
+                catch (DbUpdateConcurrencyException ex)
                 {
-                    throw new InvalidOperationException($"The order has been modified by another user. Please reload the latest data and try again.");
+                    throw new InvalidOperationException("The order has been modified by another user. Please reload the latest data and try again.", ex);
                 }
 
                 pkMap.ResolvePrimaryKeys();


### PR DESCRIPTION
## Description
fix: Incorrect work with order, when 2 users try to update one order.

Added RowVersion to API model and error handling for DbUpdateConcurrencyException:
![image](https://github.com/VirtoCommerce/vc-module-order/assets/7639413/298d65cc-8a27-4f75-a5d7-dd02baa0e64a)

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-12311
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.237.0-pr-354-56b0.zip
