### PR TITLE
PT-12481: OrganizationId and OrganizationIds are missed in CustomerOrderSearchCriteria

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderSearchCriteria.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderSearchCriteria.cs
@@ -75,7 +75,7 @@ namespace VirtoCommerce.OrdersModule.Core.Model.Search
             {
                 if (_organizationIds.IsNullOrEmpty() && !string.IsNullOrEmpty(OrganizationId))
                 {
-                    _organizationIds = new[] { CustomerId };
+                    _organizationIds = new[] { OrganizationId };
                 }
                 return _organizationIds;
             }

--- a/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderSearchCriteria.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderSearchCriteria.cs
@@ -4,7 +4,6 @@ namespace VirtoCommerce.OrdersModule.Core.Model.Search
 {
     public class CustomerOrderSearchCriteria : OrderOperationSearchCriteriaBase
     {
-
         /// <summary>
         /// Search orders with flag IsPrototype
         /// </summary>
@@ -67,5 +66,23 @@ namespace VirtoCommerce.OrdersModule.Core.Model.Search
             }
         }
 
+        public string OrganizationId { get; set; }
+
+        private string[] _organizationIds;
+        public string[] OrganizationIds
+        {
+            get
+            {
+                if (_organizationIds.IsNullOrEmpty() && !string.IsNullOrEmpty(OrganizationId))
+                {
+                    _organizationIds = new[] { CustomerId };
+                }
+                return _organizationIds;
+            }
+            set
+            {
+                _organizationIds = value;
+            }
+        }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderSearchService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderSearchService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Model.Search;
 using VirtoCommerce.OrdersModule.Core.Services;
@@ -67,6 +66,8 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             query = WithParentOperationConditions(query, criteria);
 
             query = WithCustomerConditions(query, criteria);
+
+            query = WithOrganizationConditions(query, criteria);
 
             query = WithSubscriptionConditions(query, criteria);
 
@@ -135,6 +136,16 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             if (criteria.EmployeeId != null)
             {
                 query = query.Where(x => x.EmployeeId == criteria.EmployeeId);
+            }
+
+            return query;
+        }
+
+        private static IQueryable<CustomerOrderEntity> WithOrganizationConditions(IQueryable<CustomerOrderEntity> query, CustomerOrderSearchCriteria criteria)
+        {
+            if (!criteria.OrganizationIds.IsNullOrEmpty())
+            {
+                query = query.Where(x => criteria.OrganizationIds.Contains(x.CustomerId));
             }
 
             return query;

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderSearchService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderSearchService.cs
@@ -145,7 +145,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
         {
             if (!criteria.OrganizationIds.IsNullOrEmpty())
             {
-                query = query.Where(x => criteria.OrganizationIds.Contains(x.CustomerId));
+                query = query.Where(x => criteria.OrganizationIds.Contains(x.OrganizationId));
             }
 
             return query;


### PR DESCRIPTION
## Description
fix: OrganizationId and OrganizationIds are missed in CustomerOrderSearchCriteria

![image](https://github.com/VirtoCommerce/vc-module-order/assets/7639413/e236eb49-b612-4851-acb5-eddc61a25742)


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-12481
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.240.0-pr-356-ff1c.zip
