### PR TITLE
PT-12509: Entity Framework Core RowVersion column not updating using PostgreSQL

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/CustomerOrderEntityConfiguration.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/CustomerOrderEntityConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using VirtoCommerce.OrdersModule.Data.Model;
+
+namespace VirtoCommerce.OrdersModule.Data.PostgreSql
+{
+    public class CustomerOrderEntityConfiguration : IEntityTypeConfiguration<CustomerOrderEntity>
+    {
+        public void Configure(EntityTypeBuilder<CustomerOrderEntity> builder)
+        {
+            var converter = new ValueConverter<byte[], long>(
+                v => BitConverter.ToInt64(v, 0),
+                v => BitConverter.GetBytes(v));
+
+            builder.Property(c => c.RowVersion)
+                .HasColumnType("xid")
+                .HasColumnName("xmin")
+                .HasConversion(converter)
+                .ValueGeneratedOnAddOrUpdate()
+                .IsConcurrencyToken();
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20230620095341_FixRowVersion.Designer.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20230620095341_FixRowVersion.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.OrdersModule.Data.Repositories;
@@ -11,9 +12,10 @@ using VirtoCommerce.OrdersModule.Data.Repositories;
 namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
 {
     [DbContext(typeof(OrderDbContext))]
-    partial class OrderDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230620095341_FixRowVersion")]
+    partial class FixRowVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20230620095341_FixRowVersion.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20230620095341_FixRowVersion.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
+{
+    public partial class FixRowVersion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
fix: Entity Framework Core RowVersion column not updating using PostgreSQL. 

Unfortunately PostgreSQL doesn't have such auto-updating columns - but there is one feature that can be used for concurrency token. All PostgreSQL tables have a set of implicit and hidden system columns, among which xmin holds the ID of the latest updating transaction. Since this value automatically gets updated every time the row is changed, it is ideal for use as a concurrency token. The fix maps RowVersion property to system xmin.

## References
### QA-test:
### Jira-link:
### Artifact URL:
