### PR TITLE
PT-13194: Capture not showing in dynamic properties list

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Module.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Module.cs
@@ -147,6 +147,7 @@ namespace VirtoCommerce.OrdersModule.Web
             dynamicPropertyRegistrar.RegisterType<CustomerOrder>();
             dynamicPropertyRegistrar.RegisterType<PaymentIn>();
             dynamicPropertyRegistrar.RegisterType<Shipment>();
+            dynamicPropertyRegistrar.RegisterType<Capture>();
             dynamicPropertyRegistrar.RegisterType<Refund>();
             dynamicPropertyRegistrar.RegisterType<LineItem>();
 


### PR DESCRIPTION
## Description
fix: VirtoCommerce.OrdersModule.Core.Model.Capture not showing in dynamic properties list

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-13194
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.407.0-pr-372-b97b.zip
