### PR TITLE
PT-13270: Missing BeforeSaveChanges and AfterSaveChangesAsync on SaveChangesAsync

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderService.cs
@@ -64,6 +64,8 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             var changedEntries = new List<GenericChangedEntry<CustomerOrder>>();
             var changedEntities = new List<CustomerOrderEntity>();
 
+            await BeforeSaveChanges(models);
+
             using (var repository = _repositoryFactory())
             {
                 var orderIds = models.Where(x => !x.IsTransient()).Select(x => x.Id).ToArray();
@@ -148,6 +150,8 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 changedEntry.NewEntry = changedModel;
             }
 
+            await AfterSaveChangesAsync(models, changedEntries);
+
             await _eventPublisher.Publish(new OrderChangedEvent(changedEntries));
         }
 
@@ -163,6 +167,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 await repository.RemoveOrdersByIdsAsync(ids);
 
                 await repository.UnitOfWork.CommitAsync();
+
                 ClearCache(orders);
                 //Raise domain events after deletion
                 await _eventPublisher.Publish(new OrderChangedEvent(changedEntries));


### PR DESCRIPTION
## Description
fix: Missing BeforeSaveChanges and AfterSaveChangesAsync methods on SaveChangesAsync.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-13270
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.409.0-pr-374-be54.zip
