### PR TITLE
PT-13737: Allows to Update and Retry Rejected Capture and Rufund documents

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/en.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/en.VirtoCommerce.Orders.json
@@ -143,6 +143,12 @@
           "reasonCode": "Select..."
         }
       },
+      "refund-detail": {
+        "labels": {
+          "transactionId": "Transaction Id",
+          "outerId": "Outer Id"
+        }
+      },
       "capture-add": {
         "title": "Create a capture",
         "labels": {
@@ -170,72 +176,78 @@
           "vendor": "Select..."
         }
       },
-      "transactions-list": {
-        "title": "Payment gateway transactions",
-        "subtitle": "List of all payment gateway interactions"
-      },
-      "transaction-detail": {
-        "title": "Transaction details",
-        "subtitle": "Raw transaction data "
-      },
-      "shipment-detail": {
-        "title": "Shipment #{{number}}",
-        "title-new": "New shipment",
-        "subtitle": "Edit shipment details",
+      "capture-detail": {
         "labels": {
-          "shipment-method": "Shipment method",
-          "approved": "Approved",
-          "shipment-number": "Shipment ID",
-          "status": "Status",
-          "fulfillment-center": "Fulfillment center",
-          "from": "Date and time",
-          "employee": "Assigned to",
-          "price": "Shipment amount",
-          "price-with-tax": "Shipment amount with tax",
-          "shipment-method-option": "Shipment method",
-          "tracking-number": "Tracking number",
-          "tracking-url": "Tracking URL",
-          "delivery-date": "Delivery date",
-          "vendor": "Vendor"
-        },
-        "placeholders": {
-          "status": "Select...",
-          "shipment-method": "Select...",
-          "fulfillment-center": "Select or search a center...",
-          "shipment-method-option": "Default shipment method",
-          "vendor": "Select..."
-        }
-      },
-      "shipment-items": {
-        "title": "{{title}} line items",
-        "subtitle": "Edit shipment items",
-        "labels": {
-          "item": "Item",
-          "status": "Status",
-          "quantity": "Qty",
-          "price": "Price",
-          "total": "Total"
-        }
-      },
-      "catalog-items-select": {
-        "title": "Add item to order"
-      },
-      "newOperation-wizard": {
-        "title": "New operation",
-        "subtitle": "Select operation type",
-        "menu": {
-          "shipment-operation": {
-            "description": "Shipment document"
-          },
-          "payment-operation": {
-            "description": "Incoming payment document"
-          },
-          "refund-operation": {
-            "description": "Refund document"
-          }
-        }
+          "transactionId": "Transaction Id",
+          "outerId": "Outer Id"
       }
     },
+    "transactions-list": {
+      "title": "Payment gateway transactions",
+      "subtitle": "List of all payment gateway interactions"
+    },
+    "transaction-detail": {
+      "title": "Transaction details",
+      "subtitle": "Raw transaction data "
+    },
+    "shipment-detail": {
+      "title": "Shipment #{{number}}",
+      "title-new": "New shipment",
+      "subtitle": "Edit shipment details",
+      "labels": {
+        "shipment-method": "Shipment method",
+        "approved": "Approved",
+        "shipment-number": "Shipment ID",
+        "status": "Status",
+        "fulfillment-center": "Fulfillment center",
+        "from": "Date and time",
+        "employee": "Assigned to",
+        "price": "Shipment amount",
+        "price-with-tax": "Shipment amount with tax",
+        "shipment-method-option": "Shipment method",
+        "tracking-number": "Tracking number",
+        "tracking-url": "Tracking URL",
+        "delivery-date": "Delivery date",
+        "vendor": "Vendor"
+      },
+      "placeholders": {
+        "status": "Select...",
+        "shipment-method": "Select...",
+        "fulfillment-center": "Select or search a center...",
+        "shipment-method-option": "Default shipment method",
+        "vendor": "Select..."
+      }
+    },
+    "shipment-items": {
+      "title": "{{title}} line items",
+      "subtitle": "Edit shipment items",
+      "labels": {
+        "item": "Item",
+        "status": "Status",
+        "quantity": "Qty",
+        "price": "Price",
+        "total": "Total"
+      }
+    },
+    "catalog-items-select": {
+      "title": "Add item to order"
+    },
+    "newOperation-wizard": {
+      "title": "New operation",
+      "subtitle": "Select operation type",
+      "menu": {
+        "shipment-operation": {
+          "description": "Shipment document"
+        },
+        "payment-operation": {
+          "description": "Incoming payment document"
+        },
+        "refund-operation": {
+          "description": "Refund document"
+        }
+      }
+    }
+  },
     "widgets": {
       "notifications": {
         "title": "Notification feed",

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
@@ -212,6 +212,18 @@ angular.module(moduleName, [
                                 isReadOnly: true,
                                 title: "orders.blades.payment-detail.labels.from",
                                 valueType: "DateTime"
+                            },
+                            {
+                                name: 'transactionId',
+                                isReadOnly: true,
+                                title: "orders.blades.refund-detail.labels.transactionId",
+                                valueType: "ShortText"
+                            },
+                            {
+                                name: 'outerId',
+                                isReadOnly: true,
+                                title: "orders.blades.refund-detail.labels.outerId",
+                                valueType: "ShortText"
                             }
                         ]
                     }

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
@@ -235,6 +235,19 @@ angular.module(moduleName, [
                                 isReadOnly: true,
                                 title: "orders.blades.payment-detail.labels.from",
                                 valueType: "DateTime"
+                            },
+                            {
+                                name: 'transactionId',
+                                isReadOnly: true,
+                                title: "orders.blades.capture-detail.labels.transactionId",
+                                valueType: "ShortText"
+                            }
+                            ,
+                            {
+                                name: 'outerId',
+                                isReadOnly: true,
+                                title: "orders.blades.capture-detail.labels.outerId",
+                                valueType: "ShortText"
                             }
                         ]
                     }


### PR DESCRIPTION
## Description
feat: Allows to Update and Retry Rejected Capture document with same Transaction Id.
feat: Allows to Update and Retry Rejected Refund document  with same Transaction Id.
feat: Added Transaction Id and Outer Id on Capture details blade.
feat: Added Transaction Id and Outer Id on Refund details blade.

![image](https://github.com/VirtoCommerce/vc-module-order/assets/7639413/516105e9-3566-4f44-924f-d72da0f62790)

![image](https://github.com/VirtoCommerce/vc-module-order/assets/7639413/2908b4af-6f4c-4ad5-b216-e31c59382145)


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-13737
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.415.0-pr-381-04ec.zip
