### PR TITLE
PT-14655: Organization Name is empty

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.404.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.409.0-alpha.653-pt-14655-organization-name" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.400.0" />

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.409.0-alpha.653-pt-14655-organization-name" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.409.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.400.0" />

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
@@ -128,6 +128,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             order.CustomerName = cart.CustomerName;
             order.DiscountAmount = cart.DiscountAmount;
             order.OrganizationId = cart.OrganizationId;
+            order.OrganizationName = cart.OrganizationName;
             order.StoreId = cart.StoreId;
             order.TaxPercentRate = cart.TaxPercentRate;
             order.TaxType = cart.TaxType;

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/de.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/de.VirtoCommerce.Orders.json
@@ -14,6 +14,7 @@
           "from": "Von",
           "channel": "Kanal",
           "customer": "Kunde",
+          "organization": "Organisation",
           "invoice": "Erhalten Sie die Rechnung als PDF",
           "withPrototypes": "Mit vorlagen"
         },

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/en.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/en.VirtoCommerce.Orders.json
@@ -14,6 +14,7 @@
           "from": "Created at",
           "channel": "Channel",
           "customer": "Customer",
+          "organization": "Organization",
           "invoice": "Get invoice PDF",
           "withPrototypes": "With templates"
         },

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/ru.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/ru.VirtoCommerce.Orders.json
@@ -14,6 +14,7 @@
           "from": "Из",
           "channel": "Канал",
           "customer": "Покупатель",
+          "organization": "Организация",
           "invoice": "Получить счет в PDF",
           "withPrototypes": "Показать шаблоны"
         },

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-detail.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-detail.js
@@ -41,25 +41,29 @@ angular.module('virtoCommerce.orderModule')
             }
 
             blade.openCustomerDetails = function () {
-                securityAccounts.get({ id: blade.customerOrder.customerId }, function (account) {
-                    var contactId = (account && account.memberId) ? account.memberId : blade.customerOrder.customerId;
-                    members.get({ id: contactId }, function (member) {
-                        if (member && member.id) {
-                            showCustomerDetailBlade(member);
-                        }
+                if (blade.customerOrder.customerId) {
+                    securityAccounts.get({ id: blade.customerOrder.customerId }, function (account) {
+                        var contactId = (account && account.memberId) ? account.memberId : blade.customerOrder.customerId;
+                        members.get({ id: contactId }, function (member) {
+                            if (member && member.id) {
+                                showCustomerDetailBlade(member);
+                            }
+                        });
                     });
-                });
+                }
             };
 
             blade.openOrganizationDetails = function () {
-                securityAccounts.get({ id: blade.customerOrder.organizationId }, function (account) {
-                    var organizationId = (account && account.memberId) ? account.memberId : blade.customerOrder.organizationId;
-                    members.get({ id: organizationId }, function (member) {
-                        if (member && member.id) {
-                            showCustomerDetailBlade(member);
-                        }
+                if (blade.customerOrder.organizationId) {
+                    securityAccounts.get({ id: blade.customerOrder.organizationId }, function (account) {
+                        var organizationId = (account && account.memberId) ? account.memberId : blade.customerOrder.organizationId;
+                        members.get({ id: organizationId }, function (member) {
+                            if (member && member.id) {
+                                showCustomerDetailBlade(member);
+                            }
+                        });
                     });
-                });
+                }
             };
 
             blade.fetchEmployees = function (criteria) {

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-detail.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-detail.js
@@ -51,6 +51,17 @@ angular.module('virtoCommerce.orderModule')
                 });
             };
 
+            blade.openOrganizationDetails = function () {
+                securityAccounts.get({ id: blade.customerOrder.organizationId }, function (account) {
+                    var organizationId = (account && account.memberId) ? account.memberId : blade.customerOrder.organizationId;
+                    members.get({ id: organizationId }, function (member) {
+                        if (member && member.id) {
+                            showCustomerDetailBlade(member);
+                        }
+                    });
+                });
+            };
+
             blade.fetchEmployees = function (criteria) {
                 criteria.memberType = 'Employee';
                 criteria.deepSearch = true;

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-detail.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-detail.tpl.html
@@ -45,6 +45,14 @@
     </div>
 </script>
 
+<script type="text/ng-template" id="organizationSelector.html">
+  <div class="form-input">
+    <label class="form-label" style="height:27px;">
+      <a href="" ng-click="blade.openOrganizationDetails()">{{ blade.currentEntity.organizationName }}</a>
+    </label>
+  </div>
+</script>
+
 <script type="text/ng-template" id="discountAmount.html">
     <div class="form-input __currency">
         <span class="currency">{{blade.currentEntity.currency}}</span>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
@@ -114,29 +114,10 @@ angular.module(moduleName, [
                         knownChildrenOperations: ['Shipment', 'PaymentIn'],
                         metaFields: [
                             {
-                                name: 'isApproved',
-                                title: "orders.blades.customerOrder-detail.labels.approved",
-                                valueType: "Boolean",
-                                isVisibleFn: function (blade) {
-                                    return !blade.isNew;
-                                }
-                            },
-                            {
-                                name: 'employeeId',
-                                title: "orders.blades.customerOrder-detail.labels.employee",
-                                templateUrl: 'order-employeeSelector.html'
-                            },
-                            {
                                 name: 'number',
                                 isRequired: true,
                                 title: "orders.blades.customerOrder-detail.labels.order-number",
                                 valueType: "ShortText"
-                            },
-                            {
-                                name: 'createdDate',
-                                isReadOnly: true,
-                                title: "orders.blades.customerOrder-detail.labels.from",
-                                valueType: "DateTime"
                             },
                             {
                                 name: 'status',
@@ -148,14 +129,38 @@ angular.module(moduleName, [
                                 templateUrl: 'customerSelector.html'
                             },
                             {
-                                name: 'discountAmount',
-                                title: "orders.blades.customerOrder-items.labels.discount",
-                                templateUrl: 'discountAmount.html'
+                                name: 'organizationName',
+                                title: "orders.blades.customerOrder-detail.labels.organization",
+                                templateUrl: 'organizationSelector.html'
                             },
                             {
                                 name: 'storeId',
                                 title: "orders.blades.customerOrder-detail.labels.store",
                                 templateUrl: 'storeSelector.html'
+                            },
+                            {
+                                name: 'createdDate',
+                                isReadOnly: true,
+                                title: "orders.blades.customerOrder-detail.labels.from",
+                                valueType: "DateTime"
+                            },
+                            {
+                                name: 'employeeId',
+                                title: "orders.blades.customerOrder-detail.labels.employee",
+                                templateUrl: 'order-employeeSelector.html'
+                            },
+                            {
+                                name: 'discountAmount',
+                                title: "orders.blades.customerOrder-items.labels.discount",
+                                templateUrl: 'discountAmount.html'
+                            },
+                            {
+                                name: 'isApproved',
+                                title: "orders.blades.customerOrder-detail.labels.approved",
+                                valueType: "Boolean",
+                                isVisibleFn: function (blade) {
+                                    return !blade.isNew;
+                                }
                             }
                         ]
                     }

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.447.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Cart" version="3.404.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.409.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.401.0" />
     <dependency id="VirtoCommerce.Core" version="3.400.0" />
     <dependency id="VirtoCommerce.Customer" version="3.400.0" />


### PR DESCRIPTION
## Description
fix: Organization Name is empty

![Organization-Name](https://github.com/VirtoCommerce/vc-module-order/assets/7639413/216b3946-c93c-4570-84fd-a359accdbd6f)

Please note that this release does not update the OrganizationName in the Cart and Order entities in the database. To update these entities, you can use the script provided below. The script updates the OrganizationName in the Cart and CustomerOrder tables by joining it with the Member table on the Id in Member and OrganizationId. 

> If you store Cart, CustomerOrder, and Member in different databases, you will need to modify the script accordingly.

```sql
-- SqlServer Script
UPDATE Cart SET OrganizationName = m.[Name] FROM Cart c
JOIN Member m ON c.OrganizationId = m.Id AND c.Type IS NULL

UPDATE CustomerOrder SET OrganizationName = m.[Name] FROM Cart c
JOIN Member m ON c.OrganizationId = m.Id
```


## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-14655
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.424.0-pr-393-76ad.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.424.0-pr-393-cce0.zip
