### PR TITLE
VCST-204: Filter in Orders blade doesn't work with indexing search

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderIndexedSearchCriteria.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/Search/CustomerOrderIndexedSearchCriteria.cs
@@ -1,7 +1,9 @@
+using System;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.OrdersModule.Core.Model.Search
 {
+    [Obsolete("Use CustomerOrderSearchCriteria", DiagnosticId = "VC0008", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
     public class CustomerOrderIndexedSearchCriteria : SearchCriteriaBase
     {
     }

--- a/src/VirtoCommerce.OrdersModule.Core/Search/Indexed/IIndexedCustomerOrderSearchService.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Search/Indexed/IIndexedCustomerOrderSearchService.cs
@@ -5,6 +5,6 @@ namespace VirtoCommerce.OrdersModule.Core.Search.Indexed
 {
     public interface IIndexedCustomerOrderSearchService
     {
-        Task<CustomerOrderSearchResult> SearchCustomerOrdersAsync(CustomerOrderIndexedSearchCriteria criteria);
+        Task<CustomerOrderSearchResult> SearchCustomerOrdersAsync(CustomerOrderSearchCriteria criteria);
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Search/Indexed/FilterHelper.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Search/Indexed/FilterHelper.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.SearchModule.Core.Model;
+
+namespace VirtoCommerce.OrdersModule.Data.Search.Indexed
+{
+    public static class FilterHelper
+    {
+        public static IFilter CreateTermFilter(string fieldName, string value)
+        {
+            return new TermFilter
+            {
+                FieldName = fieldName,
+                Values = new[] { value },
+            };
+        }
+
+        public static IFilter CreateTermFilter(string fieldName, IEnumerable<string> values)
+        {
+            return new TermFilter
+            {
+                FieldName = fieldName,
+                Values = values.ToArray(),
+            };
+        }
+
+        public static IFilter CreateDateRangeFilter(string fieldName, DateTime? lower, DateTime? upper, bool includeLower, bool includeUpper)
+        {
+            return CreateRangeFilter(fieldName, lower?.ToString("O"), upper?.ToString("O"), includeLower, includeUpper);
+        }
+
+        public static IFilter CreateRangeFilter(string fieldName, string lower, string upper, bool includeLower, bool includeUpper)
+        {
+            return new RangeFilter
+            {
+                FieldName = fieldName,
+                Values = new[] { CreateRangeFilterValue(lower, upper, includeLower, includeUpper) },
+            };
+        }
+
+        public static RangeFilterValue CreateRangeFilterValue(string lower, string upper, bool includeLower, bool includeUpper)
+        {
+            return new RangeFilterValue
+            {
+                Lower = lower,
+                Upper = upper,
+                IncludeLower = includeLower,
+                IncludeUpper = includeUpper,
+            };
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Search/Indexed/IndexedCustomerOrderSearchService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Search/Indexed/IndexedCustomerOrderSearchService.cs
@@ -30,7 +30,7 @@ namespace VirtoCommerce.OrdersModule.Data.Search.Indexed
             _configuration = configuration;
         }
 
-        public virtual async Task<CustomerOrderSearchResult> SearchCustomerOrdersAsync(CustomerOrderIndexedSearchCriteria criteria)
+        public virtual async Task<CustomerOrderSearchResult> SearchCustomerOrdersAsync(CustomerOrderSearchCriteria criteria)
         {
             if (!_configuration.IsOrderFullTextSearchEnabled())
             {
@@ -46,7 +46,7 @@ namespace VirtoCommerce.OrdersModule.Data.Search.Indexed
             return result;
         }
 
-        protected virtual async Task<CustomerOrderSearchResult> ConvertResponseAsync(SearchResponse response, CustomerOrderIndexedSearchCriteria criteria)
+        protected virtual async Task<CustomerOrderSearchResult> ConvertResponseAsync(SearchResponse response, CustomerOrderSearchCriteria criteria)
         {
             var result = AbstractTypeFactory<CustomerOrderSearchResult>.TryCreateInstance();
 
@@ -59,7 +59,7 @@ namespace VirtoCommerce.OrdersModule.Data.Search.Indexed
             return result;
         }
 
-        protected virtual async Task<IList<CustomerOrder>> ConvertDocumentsAsync(IList<SearchDocument> documents, CustomerOrderIndexedSearchCriteria criteria)
+        protected virtual async Task<IList<CustomerOrder>> ConvertDocumentsAsync(IList<SearchDocument> documents, CustomerOrderSearchCriteria criteria)
         {
             var result = new List<CustomerOrder>();
 

--- a/src/VirtoCommerce.OrdersModule.Web/Controllers/Api/OrderModuleController.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Controllers/Api/OrderModuleController.cs
@@ -716,7 +716,7 @@ namespace VirtoCommerce.OrdersModule.Web.Controllers.Api
 
         [HttpPost]
         [Route("indexed/search")]
-        public async Task<ActionResult<CustomerOrderSearchResult>> SearchCustomerOrderIndexed([FromBody] CustomerOrderIndexedSearchCriteria criteria)
+        public async Task<ActionResult<CustomerOrderSearchResult>> SearchCustomerOrderIndexed([FromBody] CustomerOrderSearchCriteria criteria)
         {
             var result = await _indexedSearchService.SearchCustomerOrdersAsync(criteria);
             return Content(JsonConvert.SerializeObject(result, _outputJsonSerializerSettings), "application/json");

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-list.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-list.js
@@ -72,7 +72,11 @@ function ($rootScope, $scope, $localStorage, customerOrders, bladeUtils, dialogS
                 angular.extend(criteria, filter.current);
             }
 
-            var endpoint = $scope.useIndexedSearch ? customerOrders.indexedSearch : customerOrders.search;
+            var endpoint = customerOrders.search;
+
+            if ($scope.useIndexedSearch && (criteria.keyword || filter.current)) {
+                endpoint = customerOrders.indexedSearch;
+            }
 
             endpoint(criteria, function (data) {
                 blade.isLoading = false;


### PR DESCRIPTION
## Description
fix: The fix resolves that filter in orders blade doesn't work with indexing search.
feat: Enhancement to the data retrieval process by utilizing the api/order/customerOrders/search endpoint. Instead of relying on indexing search during data loading without specific filters, this update ensures more efficient access to non-indexed data, particularly when indexation is still in progress.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-204
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.802.0-pr-398-4644.zip
