### PR TITLE
VCST-398: Close Transaction switcher in Capture document should not be active for editing

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/capture-detail.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/capture-detail.html
@@ -38,7 +38,7 @@
                 <label class="form-label">{{ 'orders.blades.capture-details.labels.closeTransaction' | translate }}</label>
                 <div class="form-input">
                   <label class="form-label __switch">
-                    <input type="checkbox" ng-model="blade.currentEntity.closeTransaction" />
+                    <input type="checkbox" ng-model="blade.currentEntity.closeTransaction" ng-disabled="true" />
                     <span class="switch"></span>
                   </label>
                 </div>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/capture-detail.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/capture-detail.html
@@ -32,7 +32,7 @@
             </div>
           </div>
 
-          <div class="form columns clearfix">
+          <!--<div class="form columns clearfix">
             <div class="column">
               <div class="form-group">
                 <label class="form-label">{{ 'orders.blades.capture-details.labels.closeTransaction' | translate }}</label>
@@ -44,7 +44,7 @@
                 </div>
               </div>
 
-            </div>
+            </div>-->
         </fieldset>
       </form>
       <va-widget-container group="captureDetailWidgets" blade="blade" gridster-opts="{width: 526}"></va-widget-container>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/order.js
@@ -258,8 +258,13 @@ angular.module(moduleName, [
                                 isReadOnly: true,
                                 title: "orders.blades.capture-detail.labels.transactionId",
                                 valueType: "ShortText"
-                            }
-                            ,
+                            },
+                            {
+                                name: 'closeTransaction',
+                                isReadOnly: true,
+                                title: 'orders.blades.capture-details.labels.closeTransaction',
+                                valueType: "ShortText"
+                            },
                             {
                                 name: 'outerId',
                                 isReadOnly: true,


### PR DESCRIPTION
## Description
feat: The Close Transaction switcher in the Capture document is now disabled for editing. It is preventing any unintended effects on the Payment provider.

![image](https://github.com/VirtoCommerce/vc-module-order/assets/7639413/28a7cb00-44c6-4708-922c-a4823a96897a)


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-398
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.805.0-pr-405-2ec1.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.805.0-pr-405-aa80.zip
