### PR TITLE
VCST-1752: Performance Degradation in MS SQL Database

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/DbContextOptionsBuilderExtensions.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/DbContextOptionsBuilderExtensions.cs
@@ -7,10 +7,11 @@ namespace VirtoCommerce.OrdersModule.Data.SqlServer
         /// <summary>
         /// Configures the context to use SqlServer.
         /// </summary>
-        public static DbContextOptionsBuilder UseSqlServerDatabase(this DbContextOptionsBuilder builder, string connectionString)
+        public static DbContextOptionsBuilder UseSqlServerDatabase(this DbContextOptionsBuilder builder, string connectionString, int compatibilityLevel)
         {
             return builder.UseSqlServer(connectionString, db => db
-                .MigrationsAssembly(typeof(SqlServerDbContextFactory).Assembly.GetName().Name));
+                .MigrationsAssembly(typeof(SqlServerDbContextFactory).Assembly.GetName().Name)
+                .UseCompatibilityLevel(compatibilityLevel));
         }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Web/Module.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Module.cs
@@ -70,7 +70,8 @@ namespace VirtoCommerce.OrdersModule.Web
                         options.UsePostgreSqlDatabase(connectionString);
                         break;
                     default:
-                        options.UseSqlServerDatabase(connectionString);
+                        var compatibilityLevel = Configuration.GetValue("SqlServer:CompatibilityLevel", 120);
+                        options.UseSqlServerDatabase(connectionString, compatibilityLevel);
                         break;
                 }
             });


### PR DESCRIPTION
## Description
fix: Addressed performance degradation in MS SQL Database when using OPENJSON and CONTAINS. The issue was resolved by setting the CompatibilityLevel to 120. For more details, refer to this link: https://www.virtocommerce.org/t/performance-degradation-in-ms-sql-database-queries-after-upgrading-to-ef-core-8/731.

feat: Added connfiguration in appsettings.json  SqlServer:CompatibilityLevel fto set up the compatibility level for SQL Server. The default value is set to 120.

```json
  "SqlServer": {
    "CompatibilityLevel": 120
  }
```
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1752
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.826.0-pr-429-b0d8.zip