### PR TITLE
feat: reset column sorting when search by keyword

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-list.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-list.js
@@ -228,6 +228,10 @@ angular.module('virtoCommerce.orderModule')
         };
 
     filter.criteriaChanged = function () {
+        if (filter.keyword) {
+            $scope.gridApi.grid.resetColumnSorting();
+        }
+
         if ($scope.pageSettings.currentPage > 1) {
             $scope.pageSettings.currentPage = 1;
         } else {


### PR DESCRIPTION
## Description
Reset column sorting when user using search by keyword in orders list
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.842.0-pr-448-e13e.zip