### PR TITLE
VCST-3426: Update filter name binding in customer order list

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-list.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-list.tpl.html
@@ -4,7 +4,7 @@
         <a class="add" left-click-menu data-target="filterSearch{{blade.id}}" style="margin: 0 20px 0 0;">{{ filter.current ? filter.current.name : 'orders.blades.customerOrder-list.placeholders.select-filter' | translate }} <i class="form-ico fa fa-caret-down"></i></a>
         <ul class="menu __context" role="menu" id="filterSearch{{blade.id}}" style="width: 170px;">
           <li ng-repeat="x in $localStorage.orderSearchFilters" class="splited-element menu-item">
-            <i class="menu-ico fas fa-plus" ng-if="!x.id"></i> <span ng-click='filter.current=x;filter.change();' ng-bind-html="x.name | translate"></span>
+            <i class="menu-ico fas fa-plus" ng-if="!x.id"></i> <span ng-click='filter.current=x;filter.change();' ng-bind="x.name | translate"></span>
             <i class="fa fa-pencil right-alignment" ng-click='filter.current=x;filter.edit($event)' ng-if="x.id"></i>
           </li>
         </ul>


### PR DESCRIPTION
## Description
fix: Replaced `ng-bind-html` with `ng-bind` for the filter name in the customer order list template. This change ensures that the filter name is treated as plain text, improving security and rendering consistency. The overall structure of the dropdown menu remains unchanged.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3426
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.851.0-pr-457-1cd3.zip