### PR TITLE
VCST-4983: Improve refund flow

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
@@ -103,11 +103,10 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                     }
                     else
                     {
-                        // A failed modification must not reject the underlying refund: preserve the prior status
-                        // unless the provider explicitly reports a new one.
-                        refund.Status = result.NewRefundStatus != default
-                            ? result.NewRefundStatus.ToString()
-                            : previousStatus;
+                        // A failed modification must not invalidate the underlying refund state.
+                        // NewRefundStatus is non-nullable and defaults to Pending, so we cannot distinguish
+                        // "provider didn't set it" from "provider explicitly reports Pending" -- preserve prior state.
+                        refund.Status = previousStatus;
                         refund.RejectReasonMessage = result.ErrorMessage;
                     }
 
@@ -172,11 +171,13 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
 
         protected virtual bool HasRefundFieldChanges(Refund oldRefund, Refund newRefund)
         {
+            // Status is intentionally NOT tracked here: the handler itself writes refund.Status from the
+            // provider response, and tracking it would re-trigger the handler from its own SaveChangesAsync,
+            // causing duplicate provider calls. Manual status edits on submitted refunds are blocked at the UI.
             return oldRefund.Amount != newRefund.Amount
                 || oldRefund.ReasonCode != newRefund.ReasonCode
                 || oldRefund.ReasonMessage != newRefund.ReasonMessage
                 || oldRefund.OuterId != newRefund.OuterId
-                || oldRefund.Status != newRefund.Status
                 || oldRefund.IsCancelled != newRefund.IsCancelled;
         }
     }

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
@@ -92,16 +92,22 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                     { "IsUpdate", "true" },
                 };
 
+                var previousStatus = refund.Status;
                 try
                 {
                     var result = await payment.PaymentMethod.RefundProcessPaymentAsync(refundRequest);
                     if (result.IsSuccess)
                     {
                         refund.Status = result.NewRefundStatus.ToString();
+                        refund.RejectReasonMessage = null;
                     }
                     else
                     {
-                        refund.Status = nameof(RefundStatus.Rejected);
+                        // A failed modification must not reject the underlying refund: preserve the prior status
+                        // unless the provider explicitly reports a new one.
+                        refund.Status = result.NewRefundStatus != default
+                            ? result.NewRefundStatus.ToString()
+                            : previousStatus;
                         refund.RejectReasonMessage = result.ErrorMessage;
                     }
 
@@ -169,7 +175,9 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
             return oldRefund.Amount != newRefund.Amount
                 || oldRefund.ReasonCode != newRefund.ReasonCode
                 || oldRefund.ReasonMessage != newRefund.ReasonMessage
-                || oldRefund.OuterId != newRefund.OuterId;
+                || oldRefund.OuterId != newRefund.OuterId
+                || oldRefund.Status != newRefund.Status
+                || oldRefund.IsCancelled != newRefund.IsCancelled;
         }
     }
 

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
@@ -99,6 +99,10 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                     if (result.IsSuccess)
                     {
                         refund.Status = result.NewRefundStatus.ToString();
+                        if (!string.IsNullOrEmpty(result.OuterId))
+                        {
+                            refund.OuterId = result.OuterId;
+                        }
                         refund.RejectReasonMessage = null;
                     }
                     else

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
@@ -171,13 +171,13 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
 
         protected virtual bool HasRefundFieldChanges(Refund oldRefund, Refund newRefund)
         {
-            // Status is intentionally NOT tracked here: the handler itself writes refund.Status from the
-            // provider response, and tracking it would re-trigger the handler from its own SaveChangesAsync,
-            // causing duplicate provider calls. Manual status edits on submitted refunds are blocked at the UI.
+            // Status and OuterId are intentionally NOT tracked here: both are written by the provider response
+            // (via PaymentFlowService.SaveResultToRefundDocument or this handler), so tracking them would
+            // re-trigger the handler from its own SaveChangesAsync and cause duplicate provider calls.
+            // Manual status edits on submitted refunds are blocked at the UI.
             return oldRefund.Amount != newRefund.Amount
                 || oldRefund.ReasonCode != newRefund.ReasonCode
                 || oldRefund.ReasonMessage != newRefund.ReasonMessage
-                || oldRefund.OuterId != newRefund.OuterId
                 || oldRefund.IsCancelled != newRefund.IsCancelled;
         }
     }

--- a/src/VirtoCommerce.OrdersModule.Data/Services/PaymentFlowService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/PaymentFlowService.cs
@@ -242,6 +242,10 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             if (refundResult.IsSuccess)
             {
                 refund.Status = refundResult.NewRefundStatus.ToString();
+                if (!string.IsNullOrEmpty(refundResult.OuterId))
+                {
+                    refund.OuterId = refundResult.OuterId;
+                }
                 result.RefundStatus = refund.Status;
                 result.Succeeded = true;
             }
@@ -343,6 +347,10 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             if (captureResult.IsSuccess)
             {
                 capture.Status = nameof(CaptureStatus.Processed);
+                if (!string.IsNullOrEmpty(captureResult.OuterId))
+                {
+                    capture.OuterId = captureResult.OuterId;
+                }
                 paymentInfo.Payment.Status = captureResult.NewPaymentStatus.ToString();
                 result.PaymentStatus = paymentInfo.Payment.Status;
                 result.Succeeded = true;

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/operation-detail.js
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/operation-detail.js
@@ -271,6 +271,11 @@ angular.module('virtoCommerce.orderModule')
                                 || blade.currentEntity.cancelledState === 'Completed'
                                 || blade.currentEntity.cancelledState === 'Requested');
                             break;
+                        case 'Refund':
+                            result = !blade.currentEntity.isCancelled
+                                && blade.currentEntity.status !== 'Processed'
+                                && !blade.currentEntity.outerId;
+                            break;
                         default:
                             result = !blade.currentEntity.isCancelled;
                             break;

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/refund-detail.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/refund-detail.html
@@ -19,7 +19,7 @@
                                                          placeholder="'orders.blades.refund-details.placeholders.status' | translate"
                                                          setting="'Refund.Status'"
                                                          ng-model="blade.currentEntity.status"
-                                                         disabled="blade.isLocked"></va-setting-value-select>
+                                                         disabled="blade.isLocked || blade.currentEntity.outerId || blade.currentEntity.status === 'Processed'"></va-setting-value-select>
                             </div>
                             <div class="form-group">
                                 <label class="form-label">{{ 'orders.blades.refund-details.labels.amount' | translate }}</label>

--- a/tests/VirtoCommerce.OrdersModule.Tests/VirtoCommerce.OrdersModule.Tests.csproj
+++ b/tests/VirtoCommerce.OrdersModule.Tests/VirtoCommerce.OrdersModule.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: OuterId returned from provider is discarded
fix: Modification failure wrongly rejects the refund
fix: Cancel Document & manual status edit bypass the payment method


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4983
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1006.0-pr-494-f345.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment/refund state transitions and provider-callback persistence, which can affect financial operation workflows if edge cases are missed. Changes are localized but impact critical order/payment documents and UI guardrails.
> 
> **Overview**
> Fixes refund/capture provider response handling so a non-empty provider `OuterId` is persisted when saving refund/capture results.
> 
> Adjusts refund modification flow to **preserve the prior refund status** when an update call fails (instead of forcing `Rejected`), clears reject reason on success, and avoids retriggering provider calls by excluding `Status`/`OuterId` from refund-change detection (tracking `IsCancelled` instead). The UI now blocks *cancel* and manual *status edits* for refunds that are `Processed` or already have an `outerId`.
> 
> Updates test tooling by bumping `coverlet.collector` to `10.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34553cbb9633d55c2f0d49f54e8696334b53c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->