### PR TITLE
VCST-5075: Reject capture/refund requests without a positive amount

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/PaymentErrorDescriber.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/PaymentErrorDescriber.cs
@@ -43,5 +43,10 @@ namespace VirtoCommerce.OrdersModule.Core.Model
         {
             return $"Internal payment method error";
         }
+
+        public static string AmountRequired()
+        {
+            return "Amount is required and must be greater than zero";
+        }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Services/PaymentFlowService.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/PaymentFlowService.cs
@@ -133,6 +133,14 @@ namespace VirtoCommerce.OrdersModule.Data.Services
         {
             var result = AbstractTypeFactory<RefundOrderPaymentResult>.TryCreateInstance();
 
+            if (request.Amount is null or <= 0)
+            {
+                result.Succeeded = false;
+                result.ErrorCode = PaymentFlowErrorCodes.InvalidRequestError;
+                result.ErrorMessage = PaymentErrorDescriber.AmountRequired();
+                return result;
+            }
+
             var paymentInfo = await GetPaymentInfoAsync(request, RefundAllowedPaymentStatuses);
 
             // validate payment
@@ -171,7 +179,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
         protected virtual void UpdateRefund(Refund refund, PaymentIn payment, Store store, RefundOrderPaymentRequest request)
         {
-            refund.Amount = request.Amount ?? payment.Sum;
+            refund.Amount = request.Amount.Value;
             refund.ReasonCode = EnumUtility.SafeParse(request.ReasonCode, RefundReasonCode.Other);
             refund.ReasonMessage = request.ReasonMessage;
             refund.Comment = request.ReasonMessage;
@@ -191,7 +199,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             var numberTemplate = store.Settings.GetValue<string>(Core.ModuleConstants.Settings.General.RefundNewNumberTemplate);
             refund.Number = uniqueNumberGenerator.GenerateNumber(store.Id, numberTemplate);
 
-            refund.Amount = request.Amount ?? payment.Sum;
+            refund.Amount = request.Amount.Value;
             refund.ReasonCode = EnumUtility.SafeParse(request.ReasonCode, RefundReasonCode.Other);
             refund.ReasonMessage = request.ReasonMessage;
             refund.Comment = request.ReasonMessage;
@@ -220,7 +228,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
             FillPaymentRequestBase(paymentInfo, result);
 
-            result.AmountToRefund = request.Amount ?? paymentInfo.Payment.Sum;
+            result.AmountToRefund = request.Amount.Value;
             result.Reason = request.ReasonCode;
             result.Notes = request.ReasonMessage;
             result.OuterId = request.OuterId;
@@ -299,6 +307,14 @@ namespace VirtoCommerce.OrdersModule.Data.Services
         public virtual async Task<CaptureOrderPaymentResult> CreateCaptureDocument(CaptureOrderPaymentRequest request)
         {
             var result = AbstractTypeFactory<CaptureOrderPaymentResult>.TryCreateInstance();
+
+            if (request.Amount is null or <= 0)
+            {
+                result.Succeeded = false;
+                result.ErrorCode = PaymentFlowErrorCodes.InvalidRequestError;
+                result.ErrorMessage = PaymentErrorDescriber.AmountRequired();
+                return result;
+            }
 
             // Paid status is also available for capture operation, since in case of multiple captures per single payment we don't know when it will be the last capture
             var paymentInfo = await GetPaymentInfoAsync(request, CaptureAllowedPaymentStatuses);
@@ -423,7 +439,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
             FillPaymentRequestBase(paymentInfo, result);
 
-            result.CaptureAmount = request.Amount ?? paymentInfo.Payment.Sum;
+            result.CaptureAmount = request.Amount.Value;
             result.OuterId = request.OuterId;
 
             result.Parameters ??= [];
@@ -442,7 +458,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             var numberTemplate = store.Settings.GetValue<string>(Core.ModuleConstants.Settings.General.CaptureNewNumberTemplate);
             capture.Number = uniqueNumberGenerator.GenerateNumber(store.Id, numberTemplate);
 
-            capture.Amount = request.Amount ?? payment.Sum;
+            capture.Amount = request.Amount.Value;
             capture.Comment = request.CaptureDetails;
             capture.OuterId = request.OuterId;
             capture.TransactionId = request.TransactionId;
@@ -458,7 +474,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
         protected virtual void UpdateCapture(Capture capture, PaymentIn payment, Store store, CaptureOrderPaymentRequest request)
         {
-            capture.Amount = request.Amount ?? payment.Sum;
+            capture.Amount = request.Amount.Value;
             capture.Comment = request.CaptureDetails;
             capture.OuterId = request.OuterId;
             capture.TransactionId = request.TransactionId;

--- a/tests/VirtoCommerce.OrdersModule.Tests/PaymentFlowServiceTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/PaymentFlowServiceTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.CoreModule.Core.Common;
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.OrdersModule.Core.Services;
+using VirtoCommerce.OrdersModule.Data.Services;
+using VirtoCommerce.Platform.Core.DistributedLock;
+using VirtoCommerce.StoreModule.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.OrdersModule.Tests
+{
+    [Trait("Category", "Unit")]
+    public class PaymentFlowServiceTests
+    {
+        private readonly Mock<ICustomerOrderService> _customerOrderServiceMock = new();
+        private readonly Mock<IPaymentService> _paymentServiceMock = new();
+        private readonly Mock<IStoreService> _storeServiceMock = new();
+        private readonly Mock<IValidator<OrderPaymentInfo>> _validatorMock = new();
+        private readonly Mock<ITenantUniqueNumberGenerator> _numberGeneratorMock = new();
+        private readonly Mock<IDistributedLockService> _lockServiceMock = new();
+
+        private readonly PaymentFlowService _service;
+
+        public PaymentFlowServiceTests()
+        {
+            var lockOptions = Options.Create(new PaymentDistributedLockOptions());
+
+            _lockServiceMock
+                .Setup(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<Task<CaptureOrderPaymentResult>>>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken?>()))
+                .Returns<string, Func<Task<CaptureOrderPaymentResult>>, TimeSpan?, TimeSpan?, TimeSpan?, CancellationToken?>(
+                    (_, action, _, _, _, _) => action());
+
+            _lockServiceMock
+                .Setup(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<Task<RefundOrderPaymentResult>>>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken?>()))
+                .Returns<string, Func<Task<RefundOrderPaymentResult>>, TimeSpan?, TimeSpan?, TimeSpan?, CancellationToken?>(
+                    (_, action, _, _, _, _) => action());
+
+            _service = new PaymentFlowService(
+                _customerOrderServiceMock.Object,
+                _paymentServiceMock.Object,
+                _storeServiceMock.Object,
+                _validatorMock.Object,
+                _numberGeneratorMock.Object,
+                lockOptions,
+                _lockServiceMock.Object);
+        }
+
+        public static IEnumerable<object[]> InvalidAmounts => new[]
+        {
+            new object[] { (decimal?)null },
+            new object[] { 0m },
+            new object[] { -10m },
+        };
+
+        [Theory]
+        [MemberData(nameof(InvalidAmounts))]
+        public async Task CapturePaymentAsync_AmountIsMissingOrNonPositive_ReturnsInvalidRequestError(decimal? amount)
+        {
+            var request = new CaptureOrderPaymentRequest
+            {
+                OrderId = "order-1",
+                TransactionId = "txn-1",
+                OuterId = "outer-1",
+                Amount = amount,
+            };
+
+            var result = await _service.CapturePaymentAsync(request);
+
+            result.Succeeded.Should().BeFalse();
+            result.ErrorCode.Should().Be(PaymentFlowErrorCodes.InvalidRequestError);
+            result.ErrorMessage.Should().Be(PaymentErrorDescriber.AmountRequired());
+
+            _validatorMock.Verify(
+                x => x.ValidateAsync(It.IsAny<ValidationContext<OrderPaymentInfo>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            _customerOrderServiceMock.Verify(
+                x => x.SaveChangesAsync(It.IsAny<IList<CustomerOrder>>()),
+                Times.Never);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidAmounts))]
+        public async Task RefundPaymentAsync_AmountIsMissingOrNonPositive_ReturnsInvalidRequestError(decimal? amount)
+        {
+            var request = new RefundOrderPaymentRequest
+            {
+                OrderId = "order-1",
+                TransactionId = "txn-1",
+                OuterId = "outer-1",
+                Amount = amount,
+            };
+
+            var result = await _service.RefundPaymentAsync(request);
+
+            result.Succeeded.Should().BeFalse();
+            result.ErrorCode.Should().Be(PaymentFlowErrorCodes.InvalidRequestError);
+            result.ErrorMessage.Should().Be(PaymentErrorDescriber.AmountRequired());
+
+            _validatorMock.Verify(
+                x => x.ValidateAsync(It.IsAny<ValidationContext<OrderPaymentInfo>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            _customerOrderServiceMock.Verify(
+                x => x.SaveChangesAsync(It.IsAny<IList<CustomerOrder>>()),
+                Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
## Description
fix: Reject capture/refund requests without a positive amount

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5075
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1008.0-pr-495-04a9.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment capture/refund request validation and semantics by no longer treating a missing amount as “full amount,” which may affect existing integrations sending null amounts.
> 
> **Overview**
> `PaymentFlowService` now **validates `CaptureOrderPaymentRequest.Amount` and `RefundOrderPaymentRequest.Amount`** and immediately returns `InvalidRequestError` when the amount is missing or non-positive.
> 
> The flow no longer defaults to `payment.Sum` for capture/refund amounts (uses `request.Amount.Value` throughout), adds a dedicated `PaymentErrorDescriber.AmountRequired()` message, and includes unit tests covering null/zero/negative amounts for both operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a943517b6e69362555994ef1f9ce0659b3f767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->