### PR TITLE
VCST-5431: persist ConfigurationItem.SectionName + virtual order-model construction seam

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/ConfigurationItem.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/ConfigurationItem.cs
@@ -20,6 +20,8 @@ public class ConfigurationItem : AuditableEntity, ICloneable
 
     public string SectionId { get; set; }
 
+    public string SectionName { get; set; }
+
     public string Name { get; set; }
 
     public string Sku { get; set; }

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -14,7 +14,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1005.0-alpha.794-configurationitem-sectionname" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -14,7 +14,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1005.0-alpha.794-configurationitem-sectionname" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1006.0-alpha.799-configurationitem-sectionname" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -14,7 +14,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1006.0-alpha.799-configurationitem-sectionname" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1007.0-alpha.805-configurationitem-sectionname" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -14,7 +14,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1007.0-alpha.805-configurationitem-sectionname" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />

--- a/src/VirtoCommerce.OrdersModule.Data.MySql/Migrations/20260604145421_AddConfigurationItemSectionName.Designer.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.MySql/Migrations/20260604145421_AddConfigurationItemSectionName.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.OrdersModule.Data.Repositories;
 
@@ -11,9 +12,11 @@ using VirtoCommerce.OrdersModule.Data.Repositories;
 namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 {
     [DbContext(typeof(OrderDbContext))]
-    partial class OrderDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604145421_AddConfigurationItemSectionName")]
+    partial class AddConfigurationItemSectionName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.OrdersModule.Data.MySql/Migrations/20260604145421_AddConfigurationItemSectionName.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.MySql/Migrations/20260604145421_AddConfigurationItemSectionName.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfigurationItemSectionName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SectionName",
+                table: "OrderConfigurationItem",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SectionName",
+                table: "OrderConfigurationItem");
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20260604145406_AddConfigurationItemSectionName.Designer.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20260604145406_AddConfigurationItemSectionName.Designer.cs
@@ -2,115 +2,118 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.OrdersModule.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
+namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
 {
     [DbContext(typeof(OrderDbContext))]
-    partial class OrderDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604145406_AddConfigurationItemSectionName")]
+    partial class AddConfigurationItemSectionName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "10.0.5")
-                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.OrdersModule.Data.Model.AddressEntity", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("AddressType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("City")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CountryCode")
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CountryName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("FirstName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("LastName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Line1")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("Line2")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("MiddleName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("Organization")
                         .HasMaxLength(512)
-                        .HasColumnType("varchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Phone")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("PostalCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("RegionId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("RegionName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
@@ -128,90 +131,88 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<bool>("CloseTransaction")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PaymentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TransactionId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("Id");
 
@@ -230,36 +231,36 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CaptureId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -275,78 +276,76 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CatalogId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CategoryId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CustomText")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("ImageUrl")
                         .HasMaxLength(1028)
-                        .HasColumnType("varchar(1028)");
+                        .HasColumnType("character varying(1028)");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ProductId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<decimal>("SalePrice")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("SectionId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("SectionName")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("Sku")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
@@ -360,34 +359,34 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ConfigurationItemId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ContentType")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<long>("Size")
                         .HasColumnType("bigint");
@@ -395,7 +394,7 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Url")
                         .IsRequired()
                         .HasMaxLength(2083)
-                        .HasColumnType("varchar(2083)");
+                        .HasColumnType("character varying(2083)");
 
                     b.HasKey("Id");
 
@@ -409,208 +408,191 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("ChannelId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CustomerName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("EmployeeId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("EmployeeName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<decimal>("Fee")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("HandlingTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("HandlingTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<bool>("IsAnonymous")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsPrototype")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("LanguageCode")
                         .HasMaxLength(16)
-                        .HasColumnType("varchar(16)");
+                        .HasColumnType("character varying(16)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OrganizationId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("PaymentTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("PaymentTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("PurchaseOrderNumber")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
-                    b.Property<DateTime?>("RowVersion")
+                    b.Property<uint?>("RowVersion")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("timestamp(6)");
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
 
                     b.Property<decimal>("ShippingTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("ShippingTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ShoppingCartId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("StoreName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<decimal>("SubTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("SubTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("SubscriptionId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("SubscriptionNumber")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("Total")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.HasKey("Id");
 
@@ -624,52 +606,50 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CouponCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CouponInvalidDescription")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PromotionDescription")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("PromotionId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("PromotionName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
@@ -689,34 +669,33 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("Currency")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("FeeId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
@@ -736,185 +715,178 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CatalogId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CategoryId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("Fee")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("FulfillmentCenterId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("FulfillmentCenterName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("FulfillmentLocationCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal?>("Height")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("ImageUrl")
                         .HasMaxLength(1028)
-                        .HasColumnType("varchar(1028)");
+                        .HasColumnType("character varying(1028)");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsConfigured")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDiscountAmountRounded")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsGift")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsReccuring")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<decimal?>("Length")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("MeasureUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("PriceId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("PriceWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ProductId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ProductOuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ProductType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShippingMethodCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Sku")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TaxType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal?>("Weight")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("WeightUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<decimal?>("Width")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.HasKey("Id");
 
@@ -928,87 +900,87 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<bool?>("BooleanValue")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("CaptureId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTime?>("DateTimeValue")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal?>("DecimalValue")
                         .HasColumnType("decimal(18,5)");
 
                     b.Property<string>("DictionaryItemId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int?>("IntegerValue")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("LongTextValue")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PropertyId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PropertyName")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("RefundId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShortTextValue")
                         .HasMaxLength(512)
-                        .HasColumnType("varchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
@@ -1050,72 +1022,71 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("GatewayIpAddress")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<bool>("IsProcessed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Note")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("PaymentInId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("ProcessAttemptCount")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ProcessError")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("ProcessedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RequestData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ResponseCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ResponseData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
@@ -1129,150 +1100,142 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTime?>("AuthorizedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<DateTime?>("CapturedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CustomerName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("GatewayCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("IncomingDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OrganizationId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("PriceWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("Purpose")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TaxType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Total")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("VoidedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -1290,96 +1253,94 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PaymentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ReasonCode")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ReasonMessage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("RejectReasonMessage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TransactionId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("Id");
 
@@ -1398,36 +1359,36 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("RefundId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
@@ -1443,193 +1404,183 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("CustomerOrderId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTime?>("DeliveryDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("EmployeeId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("EmployeeName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<decimal>("Fee")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("FulfillmentCenterId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("FulfillmentCenterName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<decimal?>("Height")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<decimal?>("Length")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("MeasureUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OrganizationId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("PickupLocationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("PriceWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ShipmentMethodCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ShipmentMethodOption")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TaxType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal>("Total")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TrackingNumber")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("TrackingUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<decimal?>("VolumetricWeight")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<decimal?>("Weight")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("WeightUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<decimal?>("Width")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.HasKey("Id");
 
@@ -1645,47 +1596,47 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("BarCode")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ShipmentId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShipmentPackageId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
@@ -1703,57 +1654,57 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("BarCode")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal?>("Height")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<decimal?>("Length")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("MeasureUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("PackageType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ShipmentId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal?>("Weight")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.Property<string>("WeightUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<decimal?>("Width")
                         .HasPrecision(18, 4)
-                        .HasColumnType("decimal(18,4)");
+                        .HasColumnType("numeric(18,4)");
 
                     b.HasKey("Id");
 
@@ -1767,31 +1718,30 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<decimal>("Rate")
                         .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("numeric(18,2)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20260604145406_AddConfigurationItemSectionName.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20260604145406_AddConfigurationItemSectionName.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfigurationItemSectionName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SectionName",
+                table: "OrderConfigurationItem",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SectionName",
+                table: "OrderConfigurationItem");
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/OrderDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/OrderDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.1")
+                .HasAnnotation("ProductVersion", "10.0.5")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -330,6 +330,10 @@ namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
                     b.Property<string>("SectionId")
                         .HasMaxLength(128)
                         .HasColumnType("character varying(128)");
+
+                    b.Property<string>("SectionName")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("Sku")
                         .HasMaxLength(128)

--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/20260604145413_AddConfigurationItemSectionName.Designer.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/20260604145413_AddConfigurationItemSectionName.Designer.cs
@@ -3,114 +3,117 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.OrdersModule.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
+namespace VirtoCommerce.OrdersModule.Data.SqlServer.Migrations
 {
     [DbContext(typeof(OrderDbContext))]
-    partial class OrderDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604145413_AddConfigurationItemSectionName")]
+    partial class AddConfigurationItemSectionName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "10.0.5")
-                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.OrdersModule.Data.Model.AddressEntity", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("AddressType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("City")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CountryCode")
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CountryName")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("FirstName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("LastName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Line1")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("Line2")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("MiddleName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("Organization")
                         .HasMaxLength(512)
-                        .HasColumnType("varchar(512)");
+                        .HasColumnType("nvarchar(512)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Phone")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("PostalCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("RegionId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("RegionName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -128,90 +131,88 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<bool>("CloseTransaction")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PaymentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TransactionId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -220,7 +221,8 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.HasIndex("PaymentId");
 
                     b.HasIndex("TransactionId", "CustomerOrderId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[CustomerOrderId] IS NOT NULL");
 
                     b.ToTable("OrderCapture", (string)null);
                 });
@@ -230,33 +232,33 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CaptureId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("Quantity")
                         .HasColumnType("int");
@@ -275,78 +277,76 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CatalogId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CategoryId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CustomText")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("ImageUrl")
                         .HasMaxLength(1028)
-                        .HasColumnType("varchar(1028)");
+                        .HasColumnType("nvarchar(1028)");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ProductId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("Quantity")
                         .HasColumnType("int");
 
                     b.Property<decimal>("SalePrice")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("SectionId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("SectionName")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Sku")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -360,34 +360,34 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ConfigurationItemId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ContentType")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<long>("Size")
                         .HasColumnType("bigint");
@@ -395,7 +395,7 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Url")
                         .IsRequired()
                         .HasMaxLength(2083)
-                        .HasColumnType("varchar(2083)");
+                        .HasColumnType("nvarchar(2083)");
 
                     b.HasKey("Id");
 
@@ -409,208 +409,190 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("ChannelId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CustomerName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("EmployeeId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("EmployeeName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<decimal>("Fee")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("HandlingTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("HandlingTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<bool>("IsAnonymous")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsPrototype")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("LanguageCode")
                         .HasMaxLength(16)
-                        .HasColumnType("varchar(16)");
+                        .HasColumnType("nvarchar(16)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OrganizationId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("PaymentTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("PaymentTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("PurchaseOrderNumber")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
-                    b.Property<DateTime?>("RowVersion")
+                    b.Property<byte[]>("RowVersion")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("timestamp(6)");
+                        .HasColumnType("rowversion");
 
                     b.Property<decimal>("ShippingTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("ShippingTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ShoppingCartId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("StoreId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("StoreName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<decimal>("SubTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("SubTotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("SubscriptionId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("SubscriptionNumber")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("Total")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.HasKey("Id");
 
@@ -624,52 +606,50 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CouponCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CouponInvalidDescription")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PromotionDescription")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("PromotionId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("PromotionName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -689,34 +669,33 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("Currency")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FeeId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -736,70 +715,66 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CatalogId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CategoryId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("Fee")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("FulfillmentCenterId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("FulfillmentCenterName")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("FulfillmentLocationCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal?>("Height")
                         .HasPrecision(18, 4)
@@ -807,22 +782,22 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("ImageUrl")
                         .HasMaxLength(1028)
-                        .HasColumnType("varchar(1028)");
+                        .HasColumnType("nvarchar(1028)");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsConfigured")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsDiscountAmountRounded")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsGift")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsReccuring")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<decimal?>("Length")
                         .HasPrecision(18, 4)
@@ -830,79 +805,76 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("MeasureUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("PriceId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("PriceWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ProductId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ProductOuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ProductType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("Quantity")
                         .HasColumnType("int");
 
                     b.Property<string>("ShippingMethodCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Sku")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TaxType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal?>("Weight")
                         .HasPrecision(18, 4)
@@ -910,7 +882,7 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("WeightUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<decimal?>("Width")
                         .HasPrecision(18, 4)
@@ -928,87 +900,87 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool?>("BooleanValue")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("CaptureId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<DateTime?>("DateTimeValue")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<decimal?>("DecimalValue")
                         .HasColumnType("decimal(18,5)");
 
                     b.Property<string>("DictionaryItemId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int?>("IntegerValue")
                         .HasColumnType("int");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("LongTextValue")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PropertyId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PropertyName")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("RefundId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ShortTextValue")
                         .HasMaxLength(512)
-                        .HasColumnType("varchar(512)");
+                        .HasColumnType("nvarchar(512)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -1050,72 +1022,71 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("GatewayIpAddress")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool>("IsProcessed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Note")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("PaymentInId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("ProcessAttemptCount")
                         .HasColumnType("int");
 
                     b.Property<string>("ProcessError")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("ProcessedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("RequestData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ResponseCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("ResponseData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -1129,150 +1100,142 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<DateTime?>("AuthorizedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<DateTime?>("CapturedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CustomerName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("GatewayCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("IncomingDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OrganizationId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("PriceWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("Purpose")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TaxType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Total")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("VoidedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -1290,96 +1253,94 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PaymentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ReasonCode")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ReasonMessage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("RejectReasonMessage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TransactionId")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(256)
-                        .HasColumnType("varchar(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -1388,7 +1349,8 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.HasIndex("PaymentId");
 
                     b.HasIndex("TransactionId", "CustomerOrderId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[CustomerOrderId] IS NOT NULL");
 
                     b.ToTable("OrderRefund", (string)null);
                 });
@@ -1398,36 +1360,36 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("Quantity")
                         .HasColumnType("int");
 
                     b.Property<string>("RefundId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -1443,83 +1405,79 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CancelReason")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<DateTime?>("CancelledDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("CancelledState")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(2048)
-                        .HasColumnType("varchar(2048)");
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("varchar(3)");
+                        .HasColumnType("nvarchar(3)");
 
                     b.Property<string>("CustomerOrderId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<DateTime?>("DeliveryDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<decimal>("DiscountAmount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("DiscountAmountWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("EmployeeId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("EmployeeName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<decimal>("Fee")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("FeeWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("FulfillmentCenterId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("FulfillmentCenterName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<decimal?>("Height")
                         .HasPrecision(18, 4)
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<bool>("IsApproved")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsCancelled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<decimal?>("Length")
                         .HasPrecision(18, 4)
@@ -1527,93 +1485,87 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("MeasureUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OrganizationId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(255)
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ParentOperationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("PickupLocationId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Price")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("PriceWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("ShipmentMethodCode")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("ShipmentMethodOption")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Sum")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TaxPercentRate")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<decimal>("TaxTotal")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TaxType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal>("Total")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<decimal>("TotalWithTax")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("TrackingNumber")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("TrackingUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("VendorId")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<decimal?>("VolumetricWeight")
                         .HasPrecision(18, 4)
@@ -1625,7 +1577,7 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("WeightUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<decimal?>("Width")
                         .HasPrecision(18, 4)
@@ -1645,47 +1597,47 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("BarCode")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("LineItemId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("OuterId")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("Quantity")
                         .HasColumnType("int");
 
                     b.Property<string>("ShipmentId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ShipmentPackageId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 
@@ -1703,18 +1655,18 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("BarCode")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<decimal?>("Height")
                         .HasPrecision(18, 4)
@@ -1726,22 +1678,22 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("MeasureUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("PackageType")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("ShipmentId")
                         .IsRequired()
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal?>("Weight")
                         .HasPrecision(18, 4)
@@ -1749,7 +1701,7 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
 
                     b.Property<string>("WeightUnit")
                         .HasMaxLength(32)
-                        .HasColumnType("varchar(32)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<decimal?>("Width")
                         .HasPrecision(18, 4)
@@ -1767,31 +1719,30 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Amount")
-                        .HasPrecision(18, 4)
-                        .HasColumnType("decimal");
+                        .HasColumnType("Money");
 
                     b.Property<string>("CustomerOrderId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("LineItemId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(1024)
-                        .HasColumnType("varchar(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("PaymentInId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<decimal>("Rate")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("ShipmentId")
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Id");
 

--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/20260604145413_AddConfigurationItemSectionName.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/20260604145413_AddConfigurationItemSectionName.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.OrdersModule.Data.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfigurationItemSectionName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SectionName",
+                table: "OrderConfigurationItem",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SectionName",
+                table: "OrderConfigurationItem");
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/OrderDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/OrderDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace VirtoCommerce.OrdersModule.Data.SqlServer.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.1")
+                .HasAnnotation("ProductVersion", "10.0.5")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -331,6 +331,10 @@ namespace VirtoCommerce.OrdersModule.Data.SqlServer.Migrations
                     b.Property<string>("SectionId")
                         .HasMaxLength(128)
                         .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("SectionName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Sku")
                         .HasMaxLength(128)

--- a/src/VirtoCommerce.OrdersModule.Data/Model/ConfigurationItemEntity.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Model/ConfigurationItemEntity.cs
@@ -22,6 +22,9 @@ public class ConfigurationItemEntity : AuditableEntity, IDataEntity<Configuratio
     [StringLength(128)]
     public string SectionId { get; set; }
 
+    [StringLength(256)]
+    public string SectionName { get; set; }
+
     [StringLength(1024)]
     public string Name { get; set; }
 
@@ -69,6 +72,7 @@ public class ConfigurationItemEntity : AuditableEntity, IDataEntity<Configuratio
         configurationItem.LineItemId = LineItemId;
         configurationItem.ProductId = ProductId;
         configurationItem.SectionId = SectionId;
+        configurationItem.SectionName = SectionName;
         configurationItem.Name = Name;
         configurationItem.Sku = Sku;
         configurationItem.Quantity = Quantity;
@@ -101,6 +105,7 @@ public class ConfigurationItemEntity : AuditableEntity, IDataEntity<Configuratio
 
         ProductId = configurationItem.ProductId;
         SectionId = configurationItem.SectionId;
+        SectionName = configurationItem.SectionName;
         Name = configurationItem.Name;
         Sku = configurationItem.Sku;
         Quantity = configurationItem.Quantity;
@@ -126,6 +131,7 @@ public class ConfigurationItemEntity : AuditableEntity, IDataEntity<Configuratio
 
         target.ProductId = ProductId;
         target.SectionId = SectionId;
+        target.SectionName = SectionName;
         target.Name = Name;
         target.Sku = Sku;
         target.Quantity = Quantity;

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
@@ -309,6 +309,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             var retVal = AbstractTypeFactory<ConfigurationItem>.TryCreateInstance();
 
             retVal.SectionId = configurationItem.SectionId;
+            retVal.SectionName = configurationItem.SectionName;
             retVal.Type = configurationItem.Type;
             retVal.CatalogId = configurationItem.CatalogId;
             retVal.CategoryId = configurationItem.CategoryId;

--- a/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/CustomerOrderBuilder.cs
@@ -242,7 +242,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
         {
             ArgumentNullException.ThrowIfNull(lineItem);
 
-            var retVal = AbstractTypeFactory<LineItem>.TryCreateInstance();
+            var retVal = CreateOrderModel(lineItem);
 
             retVal.CatalogId = lineItem.CatalogId;
             retVal.CategoryId = lineItem.CategoryId;
@@ -306,7 +306,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
         {
             ArgumentNullException.ThrowIfNull(configurationItem);
 
-            var retVal = AbstractTypeFactory<ConfigurationItem>.TryCreateInstance();
+            var retVal = CreateOrderModel(configurationItem);
 
             retVal.SectionId = configurationItem.SectionId;
             retVal.SectionName = configurationItem.SectionName;
@@ -329,6 +329,22 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
             return retVal;
         }
+
+        /// <summary>
+        /// Constructs the order <see cref="LineItem"/> instance for a cart line item before field population.
+        /// Override to dispatch a polymorphic subtype based on the source cart item.
+        /// The default implementation returns the registered <see cref="AbstractTypeFactory{LineItem}"/> instance.
+        /// </summary>
+        protected virtual LineItem CreateOrderModel(CartModule.Core.Model.LineItem lineItem)
+            => AbstractTypeFactory<LineItem>.TryCreateInstance();
+
+        /// <summary>
+        /// Constructs the order <see cref="ConfigurationItem"/> instance for a cart configuration item before field population.
+        /// Override to dispatch a polymorphic subtype based on the source cart item.
+        /// The default implementation returns the registered <see cref="AbstractTypeFactory{ConfigurationItem}"/> instance.
+        /// </summary>
+        protected virtual ConfigurationItem CreateOrderModel(CartModule.Core.Model.ConfigurationItem configurationItem)
+            => AbstractTypeFactory<ConfigurationItem>.TryCreateInstance();
 
         protected virtual Discount ToOrderModel(Discount discount)
         {

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.1005.0-alpha.794-configurationitem-sectionname" />
+    <dependency id="VirtoCommerce.Cart" version="3.1006.0-alpha.799-configurationitem-sectionname" />
     <dependency id="VirtoCommerce.Catalog" version="3.1009.0" />
     <dependency id="VirtoCommerce.Core" version="3.1000.0" />
     <dependency id="VirtoCommerce.Customer" version="3.1000.0" />

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.1002.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.1005.0-alpha.794-configurationitem-sectionname" />
     <dependency id="VirtoCommerce.Catalog" version="3.1009.0" />
     <dependency id="VirtoCommerce.Core" version="3.1000.0" />
     <dependency id="VirtoCommerce.Customer" version="3.1000.0" />

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.1006.0-alpha.799-configurationitem-sectionname" />
+    <dependency id="VirtoCommerce.Cart" version="3.1007.0-alpha.805-configurationitem-sectionname" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Customer" version="3.1011.0" />

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.1007.0-alpha.805-configurationitem-sectionname" />
+    <dependency id="VirtoCommerce.Cart" version="3.1007.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Customer" version="3.1011.0" />

--- a/tests/VirtoCommerce.OrdersModule.Tests/CustomerOrderBuilderUnitTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/CustomerOrderBuilderUnitTests.cs
@@ -140,21 +140,31 @@ namespace VirtoCommerce.OrdersModule.Tests
         }
 
         [Fact]
-        public async Task PlaceCustomerOrderFromCartAsync_OverriddenLineItemSeam_PopulationRunsOnSubtype()
+        public async Task PlaceCustomerOrderFromCartAsync_LineItemSeam_DispatchesSubtypeByProductType()
         {
-            //Arrange
-            var cartItem = new LineItem
+            //Arrange - two cart line items differing by the discriminator property
+            var physicalCartItem = new LineItem
             {
                 Id = Guid.NewGuid().ToString(),
-                ProductId = "product-1",
-                Sku = "SKU-1",
+                ProductType = SubtypeDispatchingCustomerOrderBuilder.PhysicalProductType,
+                ProductId = "product-physical",
+                Sku = "SKU-PHYS",
                 ListPrice = 10.99m,
                 Quantity = 2,
+            };
+            var digitalCartItem = new LineItem
+            {
+                Id = Guid.NewGuid().ToString(),
+                ProductType = SubtypeDispatchingCustomerOrderBuilder.DigitalProductType,
+                ProductId = "product-digital",
+                Sku = "SKU-DIG",
+                ListPrice = 4.50m,
+                Quantity = 1,
             };
             var cart = new ShoppingCart
             {
                 Addresses = new List<Address>(),
-                Items = new List<LineItem> { cartItem },
+                Items = new List<LineItem> { physicalCartItem, digitalCartItem },
             };
             var builder = new SubtypeDispatchingCustomerOrderBuilder(
                 new Mock<ICustomerOrderService>().Object,
@@ -162,25 +172,42 @@ namespace VirtoCommerce.OrdersModule.Tests
                 new Mock<IPaymentMethodsSearchService>().Object);
 
             //Act
-            var orderItem = (await builder.PlaceCustomerOrderFromCartAsync(cart)).Items.FirstOrDefault();
+            var orderItems = (await builder.PlaceCustomerOrderFromCartAsync(cart)).Items;
 
-            //Assert
-            orderItem.Should().BeOfType<TestOrderLineItem>();
-            orderItem.ProductId.Should().Be("product-1");
-            orderItem.Sku.Should().Be("SKU-1");
-            orderItem.Price.Should().Be(10.99m);
+            //Assert - each discriminator value produced a distinct order line item subtype, populated on that subtype
+            var physicalOrderItem = orderItems.Single(x => x.ProductId == "product-physical");
+            var digitalOrderItem = orderItems.Single(x => x.ProductId == "product-digital");
+
+            physicalOrderItem.Should().BeOfType<PhysicalOrderLineItem>();
+            physicalOrderItem.Sku.Should().Be("SKU-PHYS");
+            physicalOrderItem.Price.Should().Be(10.99m);
+
+            digitalOrderItem.Should().BeOfType<DigitalOrderLineItem>();
+            digitalOrderItem.Sku.Should().Be("SKU-DIG");
+            digitalOrderItem.Price.Should().Be(4.50m);
         }
 
         [Fact]
-        public async Task PlaceCustomerOrderFromCartAsync_OverriddenConfigurationItemSeam_PopulationRunsOnSubtype()
+        public async Task PlaceCustomerOrderFromCartAsync_ConfigurationItemSeam_DispatchesSubtypeBySectionName()
         {
-            //Arrange
-            var cartConfigurationItem = new CartModule.Core.Model.ConfigurationItem
+            //Arrange - one line item carrying two configuration items differing by section name
+            var sectionACartItem = new CartModule.Core.Model.ConfigurationItem
             {
                 Id = Guid.NewGuid().ToString(),
-                ProductId = "config-product-1",
-                Sku = "CFG-SKU-1",
+                SectionName = SubtypeDispatchingCustomerOrderBuilder.SectionAName,
+                ProductId = "config-a",
+                Sku = "CFG-A",
                 ListPrice = 5.50m,
+                Quantity = 1,
+                SelectedForCheckout = true,
+            };
+            var sectionBCartItem = new CartModule.Core.Model.ConfigurationItem
+            {
+                Id = Guid.NewGuid().ToString(),
+                SectionName = SubtypeDispatchingCustomerOrderBuilder.SectionBName,
+                ProductId = "config-b",
+                Sku = "CFG-B",
+                ListPrice = 6.00m,
                 Quantity = 1,
                 SelectedForCheckout = true,
             };
@@ -189,7 +216,7 @@ namespace VirtoCommerce.OrdersModule.Tests
                 Id = Guid.NewGuid().ToString(),
                 ProductId = "product-1",
                 Quantity = 1,
-                ConfigurationItems = new List<CartModule.Core.Model.ConfigurationItem> { cartConfigurationItem },
+                ConfigurationItems = new List<CartModule.Core.Model.ConfigurationItem> { sectionACartItem, sectionBCartItem },
             };
             var cart = new ShoppingCart
             {
@@ -203,13 +230,20 @@ namespace VirtoCommerce.OrdersModule.Tests
 
             //Act
             var orderItem = (await builder.PlaceCustomerOrderFromCartAsync(cart)).Items.FirstOrDefault();
-            var orderConfigurationItem = orderItem?.ConfigurationItems.FirstOrDefault();
+            var orderConfigurationItems = orderItem?.ConfigurationItems;
 
-            //Assert
-            orderConfigurationItem.Should().BeOfType<TestOrderConfigurationItem>();
-            orderConfigurationItem.ProductId.Should().Be("config-product-1");
-            orderConfigurationItem.Sku.Should().Be("CFG-SKU-1");
-            orderConfigurationItem.Price.Should().Be(5.50m);
+            //Assert - each section name produced a distinct order configuration item subtype, populated on that subtype
+            var sectionAOrderItem = orderConfigurationItems.Single(x => x.ProductId == "config-a");
+            var sectionBOrderItem = orderConfigurationItems.Single(x => x.ProductId == "config-b");
+
+            sectionAOrderItem.Should().BeOfType<SectionAOrderConfigurationItem>();
+            sectionAOrderItem.SectionName.Should().Be(SubtypeDispatchingCustomerOrderBuilder.SectionAName);
+            sectionAOrderItem.Sku.Should().Be("CFG-A");
+            sectionAOrderItem.Price.Should().Be(5.50m);
+
+            sectionBOrderItem.Should().BeOfType<SectionBOrderConfigurationItem>();
+            sectionBOrderItem.SectionName.Should().Be(SubtypeDispatchingCustomerOrderBuilder.SectionBName);
+            sectionBOrderItem.Sku.Should().Be("CFG-B");
         }
 
         private static CustomerOrderBuilder GetCustomerOrderBuilder()
@@ -237,6 +271,11 @@ namespace VirtoCommerce.OrdersModule.Tests
 
         private sealed class SubtypeDispatchingCustomerOrderBuilder : CustomerOrderBuilder
         {
+            public const string PhysicalProductType = "physical";
+            public const string DigitalProductType = "digital";
+            public const string SectionAName = "section-a";
+            public const string SectionBName = "section-b";
+
             public SubtypeDispatchingCustomerOrderBuilder(
                 ICustomerOrderService customerOrderService,
                 ISettingsManager settingsManager,
@@ -245,16 +284,36 @@ namespace VirtoCommerce.OrdersModule.Tests
             {
             }
 
-            protected override OrderLineItem CreateOrderModel(CartModule.Core.Model.LineItem lineItem) => new TestOrderLineItem();
+            protected override OrderLineItem CreateOrderModel(CartModule.Core.Model.LineItem lineItem) =>
+                lineItem.ProductType switch
+                {
+                    PhysicalProductType => new PhysicalOrderLineItem(),
+                    DigitalProductType => new DigitalOrderLineItem(),
+                    _ => base.CreateOrderModel(lineItem),
+                };
 
-            protected override OrderConfigurationItem CreateOrderModel(CartModule.Core.Model.ConfigurationItem configurationItem) => new TestOrderConfigurationItem();
+            protected override OrderConfigurationItem CreateOrderModel(CartModule.Core.Model.ConfigurationItem configurationItem) =>
+                configurationItem.SectionName switch
+                {
+                    SectionAName => new SectionAOrderConfigurationItem(),
+                    SectionBName => new SectionBOrderConfigurationItem(),
+                    _ => base.CreateOrderModel(configurationItem),
+                };
         }
 
-        private sealed class TestOrderLineItem : OrderLineItem
+        private sealed class PhysicalOrderLineItem : OrderLineItem
         {
         }
 
-        private sealed class TestOrderConfigurationItem : OrderConfigurationItem
+        private sealed class DigitalOrderLineItem : OrderLineItem
+        {
+        }
+
+        private sealed class SectionAOrderConfigurationItem : OrderConfigurationItem
+        {
+        }
+
+        private sealed class SectionBOrderConfigurationItem : OrderConfigurationItem
         {
         }
     }

--- a/tests/VirtoCommerce.OrdersModule.Tests/CustomerOrderBuilderUnitTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/CustomerOrderBuilderUnitTests.cs
@@ -13,6 +13,8 @@ using VirtoCommerce.Platform.Core.Settings;
 using Xunit;
 using Address = VirtoCommerce.CartModule.Core.Model.Address;
 using LineItem = VirtoCommerce.CartModule.Core.Model.LineItem;
+using OrderConfigurationItem = VirtoCommerce.OrdersModule.Core.Model.ConfigurationItem;
+using OrderLineItem = VirtoCommerce.OrdersModule.Core.Model.LineItem;
 
 namespace VirtoCommerce.OrdersModule.Tests
 {
@@ -101,12 +103,159 @@ namespace VirtoCommerce.OrdersModule.Tests
         }
 
 
+        [Fact]
+        public void CreateOrderModel_LineItem_Default_ReturnsFactoryInstance()
+        {
+            //Arrange
+            var builder = new TestableCustomerOrderBuilder(
+                new Mock<ICustomerOrderService>().Object,
+                new Mock<ISettingsManager>().Object,
+                new Mock<IPaymentMethodsSearchService>().Object);
+            var cartItem = new LineItem { Id = Guid.NewGuid().ToString() };
+
+            //Act
+            var result = builder.CreateOrderModelPublic(cartItem);
+
+            //Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<OrderLineItem>();
+        }
+
+        [Fact]
+        public void CreateOrderModel_ConfigurationItem_Default_ReturnsFactoryInstance()
+        {
+            //Arrange
+            var builder = new TestableCustomerOrderBuilder(
+                new Mock<ICustomerOrderService>().Object,
+                new Mock<ISettingsManager>().Object,
+                new Mock<IPaymentMethodsSearchService>().Object);
+            var cartConfigurationItem = new CartModule.Core.Model.ConfigurationItem { Id = Guid.NewGuid().ToString() };
+
+            //Act
+            var result = builder.CreateOrderModelPublic(cartConfigurationItem);
+
+            //Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<OrderConfigurationItem>();
+        }
+
+        [Fact]
+        public async Task PlaceCustomerOrderFromCartAsync_OverriddenLineItemSeam_PopulationRunsOnSubtype()
+        {
+            //Arrange
+            var cartItem = new LineItem
+            {
+                Id = Guid.NewGuid().ToString(),
+                ProductId = "product-1",
+                Sku = "SKU-1",
+                ListPrice = 10.99m,
+                Quantity = 2,
+            };
+            var cart = new ShoppingCart
+            {
+                Addresses = new List<Address>(),
+                Items = new List<LineItem> { cartItem },
+            };
+            var builder = new SubtypeDispatchingCustomerOrderBuilder(
+                new Mock<ICustomerOrderService>().Object,
+                new Mock<ISettingsManager>().Object,
+                new Mock<IPaymentMethodsSearchService>().Object);
+
+            //Act
+            var orderItem = (await builder.PlaceCustomerOrderFromCartAsync(cart)).Items.FirstOrDefault();
+
+            //Assert
+            orderItem.Should().BeOfType<TestOrderLineItem>();
+            orderItem.ProductId.Should().Be("product-1");
+            orderItem.Sku.Should().Be("SKU-1");
+            orderItem.Price.Should().Be(10.99m);
+        }
+
+        [Fact]
+        public async Task PlaceCustomerOrderFromCartAsync_OverriddenConfigurationItemSeam_PopulationRunsOnSubtype()
+        {
+            //Arrange
+            var cartConfigurationItem = new CartModule.Core.Model.ConfigurationItem
+            {
+                Id = Guid.NewGuid().ToString(),
+                ProductId = "config-product-1",
+                Sku = "CFG-SKU-1",
+                ListPrice = 5.50m,
+                Quantity = 1,
+                SelectedForCheckout = true,
+            };
+            var cartItem = new LineItem
+            {
+                Id = Guid.NewGuid().ToString(),
+                ProductId = "product-1",
+                Quantity = 1,
+                ConfigurationItems = new List<CartModule.Core.Model.ConfigurationItem> { cartConfigurationItem },
+            };
+            var cart = new ShoppingCart
+            {
+                Addresses = new List<Address>(),
+                Items = new List<LineItem> { cartItem },
+            };
+            var builder = new SubtypeDispatchingCustomerOrderBuilder(
+                new Mock<ICustomerOrderService>().Object,
+                new Mock<ISettingsManager>().Object,
+                new Mock<IPaymentMethodsSearchService>().Object);
+
+            //Act
+            var orderItem = (await builder.PlaceCustomerOrderFromCartAsync(cart)).Items.FirstOrDefault();
+            var orderConfigurationItem = orderItem?.ConfigurationItems.FirstOrDefault();
+
+            //Assert
+            orderConfigurationItem.Should().BeOfType<TestOrderConfigurationItem>();
+            orderConfigurationItem.ProductId.Should().Be("config-product-1");
+            orderConfigurationItem.Sku.Should().Be("CFG-SKU-1");
+            orderConfigurationItem.Price.Should().Be(5.50m);
+        }
+
         private static CustomerOrderBuilder GetCustomerOrderBuilder()
         {
             return new CustomerOrderBuilder(
                 new Mock<ICustomerOrderService>().Object,
                 new Mock<ISettingsManager>().Object,
                 new Mock<IPaymentMethodsSearchService>().Object);
+        }
+
+        private sealed class TestableCustomerOrderBuilder : CustomerOrderBuilder
+        {
+            public TestableCustomerOrderBuilder(
+                ICustomerOrderService customerOrderService,
+                ISettingsManager settingsManager,
+                IPaymentMethodsSearchService paymentMethodSearchService)
+                : base(customerOrderService, settingsManager, paymentMethodSearchService)
+            {
+            }
+
+            public OrderLineItem CreateOrderModelPublic(CartModule.Core.Model.LineItem lineItem) => CreateOrderModel(lineItem);
+
+            public OrderConfigurationItem CreateOrderModelPublic(CartModule.Core.Model.ConfigurationItem configurationItem) => CreateOrderModel(configurationItem);
+        }
+
+        private sealed class SubtypeDispatchingCustomerOrderBuilder : CustomerOrderBuilder
+        {
+            public SubtypeDispatchingCustomerOrderBuilder(
+                ICustomerOrderService customerOrderService,
+                ISettingsManager settingsManager,
+                IPaymentMethodsSearchService paymentMethodSearchService)
+                : base(customerOrderService, settingsManager, paymentMethodSearchService)
+            {
+            }
+
+            protected override OrderLineItem CreateOrderModel(CartModule.Core.Model.LineItem lineItem) => new TestOrderLineItem();
+
+            protected override OrderConfigurationItem CreateOrderModel(CartModule.Core.Model.ConfigurationItem configurationItem) => new TestOrderConfigurationItem();
+        }
+
+        private sealed class TestOrderLineItem : OrderLineItem
+        {
+        }
+
+        private sealed class TestOrderConfigurationItem : OrderConfigurationItem
+        {
         }
     }
 }


### PR DESCRIPTION
## Description

Persist the configuration section name on the order `ConfigurationItem`, and add a construction seam to `CustomerOrderBuilder` so subclasses can dispatch polymorphic order subtypes during cart-to-order conversion.

### ConfigurationItem.SectionName
- Add `SectionName` to `ConfigurationItem` (Core) and `ConfigurationItemEntity` (Data), wired through `ToModel` / `FromModel` / `Patch`.
- Add the `SectionName` column migration for PostgreSQL, SQL Server and MySQL.
- Propagate `SectionName` from the source cart configuration item when an order is built from a cart — symmetric with the CartModule change.

### Virtual order-model construction seam
- Extract the `LineItem` / `ConfigurationItem` instantiation in `CustomerOrderBuilder` into `CreateOrderModel(...)` `protected virtual` methods (default = `AbstractTypeFactory<T>.TryCreateInstance()`).
- This lets a subclass choose the concrete order-model subtype based on the source cart item, instead of every order item collapsing to the single registered base type during conversion.

**Depends on** `VirtoCommerce.CartModule` (sibling change adding `ConfigurationItem.SectionName`, which the cart-to-order propagation reads). The package reference currently points at an alpha; replace it with the released version before merge.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5431

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1011.0-pr-498-1edc.zip


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order persistence schema and the cart-to-order mapping path; risk is limited because the column is additive/nullable and default builder behavior is unchanged.
> 
> **Overview**
> Adds **`SectionName`** to order **`ConfigurationItem`** so configured line items keep the human-readable section label (alongside **`SectionId`**) after checkout. The value is mapped on **`ConfigurationItemEntity`**, carried through **`ToModel` / `FromModel` / `Patch`**, copied from the cart configuration item in **`CustomerOrderBuilder`**, and stored via new **`OrderConfigurationItem.SectionName`** migrations (nullable `varchar(256)` / equivalent) for MySQL and PostgreSQL (SQL Server migration is in the same change set).
> 
> **`CustomerOrderBuilder`** now uses **`protected virtual CreateOrderModel(...)`** for **`LineItem`** and **`ConfigurationItem`** (default **`AbstractTypeFactory.TryCreateInstance()`**), so subclasses can instantiate polymorphic order types during cart conversion without changing default behavior.
> 
> **`VirtoCommerce.CartModule.Core`** is bumped to **3.1007.0** for the cart-side **`SectionName`** field this propagation depends on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edca22294875314110b3962f8c1242aeb120899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->