### PR TITLE
VCST-5163: Stable 15 — Orders (platform 3.1039.0)

### DIFF
--- a/samples/VirtoCommerce.OrdersModule2.Web/VirtoCommerce.OrdersModule2.Web.csproj
+++ b/samples/VirtoCommerce.OrdersModule2.Web/VirtoCommerce.OrdersModule2.Web.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.OrdersModule.Core\VirtoCommerce.OrdersModule.Core.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -14,15 +14,15 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1006.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="VirtoCommerce.OrdersModule.Data" />

--- a/src/VirtoCommerce.OrdersModule.Data.MySql/VirtoCommerce.OrdersModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data.MySql/VirtoCommerce.OrdersModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Data\VirtoCommerce.OrdersModule.Data.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/VirtoCommerce.OrdersModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/VirtoCommerce.OrdersModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Data\VirtoCommerce.OrdersModule.Data.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/VirtoCommerce.OrdersModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/VirtoCommerce.OrdersModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Data\VirtoCommerce.OrdersModule.Data.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Data/ExportImport/OrderExportImport.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/ExportImport/OrderExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -24,7 +25,7 @@ namespace VirtoCommerce.OrdersModule.Data.ExportImport
             _jsonSerializer = jsonSerializer;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -59,7 +60,7 @@ namespace VirtoCommerce.OrdersModule.Data.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.OrdersModule.Data/VirtoCommerce.OrdersModule.Data.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data/VirtoCommerce.OrdersModule.Data.csproj
@@ -16,12 +16,12 @@
   <ItemGroup>
     <PackageReference Include="AutoCompare.Core" Version="1.0.0" />
     
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1009.0" />
-    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Core\VirtoCommerce.OrdersModule.Core.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Web/Module.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -242,14 +243,14 @@ namespace VirtoCommerce.OrdersModule.Web
         }
 
         public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<OrderExportImport>().DoExportAsync(outStream,
                 progressCallback, cancellationToken);
         }
 
         public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<OrderExportImport>().DoImportAsync(inputStream,
                 progressCallback, cancellationToken);

--- a/src/VirtoCommerce.OrdersModule.Web/VirtoCommerce.OrdersModule.Web.csproj
+++ b/src/VirtoCommerce.OrdersModule.Web/VirtoCommerce.OrdersModule.Web.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DinkToPdfCopy" Version="1.0.0" />
-    <PackageReference Include="VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Data" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Data" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Core\VirtoCommerce.OrdersModule.Core.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -4,19 +4,19 @@
   <version>3.1009.0</version>
   <version-tag />
 
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.1002.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.1009.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.1006.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Inventory" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Shipping" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>Order Management</title>

--- a/src/VirtoCommerce.OrdersModule.Web/package-lock.json
+++ b/src/VirtoCommerce.OrdersModule.Web/package-lock.json
@@ -855,9 +855,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1627,9 +1627,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1647,7 +1647,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/tests/VirtoCommerce.OrdersModule.Tests/VirtoCommerce.OrdersModule.Tests.csproj
+++ b/tests/VirtoCommerce.OrdersModule.Tests/VirtoCommerce.OrdersModule.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- ICT migration; Customer dep 3.1011.0. (ISupportPartialPriceUpdate obsolete deferred.)
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide dependency and platformVersion alignment can surface breaking changes from upstream packages; export/import cancellation token type change touches platform integration but is a straightforward API swap with no logic changes in this diff.
> 
> **Overview**
> Aligns the Orders module with **Stable 15** by raising **platform** to **3.1039.0** and matching **Wave 1–5** dependency versions in `module.manifest`, Core/Data/Web/sample projects, and DB provider packages (MySql/PostgreSql/SqlServer).
> 
> Adapts to platform export/import API changes: **`ICancellationToken` is replaced with `System.Threading.CancellationToken`** on `OrderExportImport.DoExportAsync` / `DoImportAsync` and on the Web `Module` `ExportAsync` / `ImportAsync` entry points.
> 
> Minor lockfile bumps for frontend build tooling (`fast-uri`, `nanoid`, `postcss`) and **coverlet.collector** **10.0.0 → 10.0.1** in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be744dc3825fe0fce482794fd8af02457ee48392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1009.0-pr-499-be74.zip