### PR TITLE
VCST-5104: Order Totals (loyalty clone)

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrder.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrder.cs
@@ -233,6 +233,8 @@ namespace VirtoCommerce.OrdersModule.Core.Model
 
         public bool IsAnonymous { get; set; }
 
+        public IList<OrderTotal> OrderTotals { get; set; }
+
         #region ITaxable Members
 
         /// <summary>
@@ -283,6 +285,10 @@ namespace VirtoCommerce.OrdersModule.Core.Model
             {
                 Discounts = null;
             }
+            if (!orderResponseGroup.HasFlag(CustomerOrderResponseGroup.WithOrderTotals))
+            {
+                OrderTotals = null;
+            }
 
             if (!orderResponseGroup.HasFlag(CustomerOrderResponseGroup.WithPrices))
             {
@@ -305,6 +311,7 @@ namespace VirtoCommerce.OrdersModule.Core.Model
                 FeeWithTax = 0m;
                 HandlingTotal = 0m;
                 HandlingTotalWithTax = 0m;
+                OrderTotals = null;
             }
 
             foreach (var shipment in Shipments ?? Array.Empty<Shipment>())
@@ -319,7 +326,6 @@ namespace VirtoCommerce.OrdersModule.Core.Model
             {
                 item.ReduceDetails(responseGroup);
             }
-
         }
 
         public virtual void RestoreDetails(CustomerOrder order)
@@ -376,6 +382,7 @@ namespace VirtoCommerce.OrdersModule.Core.Model
             result.Shipments = Shipments?.Select(x => x.Clone()).OfType<Shipment>().ToList();
             result.Discounts = Discounts?.Select(x => x.Clone()).OfType<Discount>().ToList();
             result.FeeDetails = FeeDetails?.Select(x => x.Clone()).OfType<FeeDetail>().ToList();
+            result.OrderTotals = OrderTotals?.Select(x => x.Clone()).OfType<OrderTotal>().ToList();
 
             return result;
         }

--- a/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrderResponseGroup.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/CustomerOrderResponseGroup.cs
@@ -15,6 +15,7 @@ namespace VirtoCommerce.OrdersModule.Core.Model
         WithDynamicProperties = 1 << 6,
         WithRefunds = 1 << 7,
         WithCaptures = 1 << 8,
-        Full = WithItems | WithInPayments | WithShipments | WithAddresses | WithDiscounts | WithPrices | WithDynamicProperties | WithRefunds | WithCaptures
+        WithOrderTotals = 1 << 9,
+        Full = WithItems | WithInPayments | WithShipments | WithAddresses | WithDiscounts | WithPrices | WithDynamicProperties | WithRefunds | WithCaptures | WithOrderTotals
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Core/Model/OrderTotal.cs
+++ b/src/VirtoCommerce.OrdersModule.Core/Model/OrderTotal.cs
@@ -1,0 +1,22 @@
+using System;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.OrdersModule.Core.Model;
+
+public class OrderTotal : Entity, ICloneable
+{
+    public string CurrencyCode { get; set; }
+
+    public decimal Total { get; set; }
+
+    public decimal SubTotal { get; set; }
+
+    public decimal TaxTotal { get; set; }
+
+    public decimal DiscountTotal { get; set; }
+
+    public object Clone()
+    {
+        return MemberwiseClone();
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -182,7 +182,6 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             return currencies.First(c => c.Code == currencyCode);
         }
 
-        [Obsolete("No longer used. Use GetAllCurrencies() and GetCurrency(IList<Currency>, string) instead.", false, DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         protected virtual async Task<Currency> GetCurrency(string orderCurrencyName)
         {
             var currencies = await _currencyService.GetAllCurrenciesAsync();

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -57,11 +57,6 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 }
             }
 
-            order.DiscountTotal = 0m;
-            order.DiscountTotalWithTax = 0m;
-            order.FeeTotal = order.Fee;
-            order.TaxTotal = 0m;
-
             var ordersByCurrency = new Dictionary<string, CustomerOrder>
             {
                 { order.Currency, order }
@@ -78,79 +73,55 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 AddCustomerOrderByCurrency(ordersByCurrency, currencyCode);
             }
 
-            order.SubTotal = 0m;
-            order.SubTotalWithTax = 0m;
-            order.SubTotalTaxTotal = 0m;
-            order.SubTotalDiscount = 0m;
-            order.SubTotalDiscountWithTax = 0m;
-            order.FeeTotalWithTax = 0m;
+            var allCurrencies = GetAllCurrencies();
 
-            foreach (var (currencyCode, currencyOrder) in ordersByCurrency)
+            foreach (var (currencyCode, orderCart) in ordersByCurrency)
             {
+                orderCart.DiscountTotal = 0m;
+                orderCart.DiscountTotalWithTax = 0m;
+                orderCart.FeeTotal = orderCart.Fee;
+                orderCart.FeeTotalWithTax = 0m;
+                orderCart.TaxTotal = 0m;
+
+                // Line items
                 var currencyItems = order.Items?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+                orderCart.SubTotal = currencyItems.Sum(x => x.ListTotal);
+                orderCart.SubTotalWithTax = currencyItems.Sum(x => x.ListTotalWithTax);
+                orderCart.SubTotalTaxTotal = currencyItems.Sum(x => x.TaxTotal);
+                orderCart.SubTotalDiscount = currencyItems.Sum(x => x.DiscountTotal);
+                orderCart.SubTotalDiscountWithTax = currencyItems.Sum(x => x.DiscountTotalWithTax);
+                orderCart.DiscountTotal += currencyItems.Sum(x => x.DiscountTotal);
+                orderCart.DiscountTotalWithTax += currencyItems.Sum(x => x.DiscountTotalWithTax);
+                orderCart.FeeTotal += currencyItems.Sum(x => x.Fee);
+                orderCart.FeeTotalWithTax += currencyItems.Sum(x => x.FeeWithTax);
+                orderCart.TaxTotal += currencyItems.Sum(x => x.TaxTotal);
 
-                currencyOrder.SubTotal = currencyItems.Sum(x => x.ListTotal);
-                currencyOrder.SubTotalWithTax = currencyItems.Sum(x => x.ListTotalWithTax);
-                currencyOrder.SubTotalTaxTotal = currencyItems.Sum(x => x.TaxTotal);
-                currencyOrder.SubTotalDiscount = currencyItems.Sum(x => x.DiscountTotal);
-                currencyOrder.SubTotalDiscountWithTax = currencyItems.Sum(x => x.DiscountTotalWithTax);
-                currencyOrder.DiscountTotal += currencyItems.Sum(x => x.DiscountTotal);
-                currencyOrder.DiscountTotalWithTax += currencyItems.Sum(x => x.DiscountTotalWithTax);
-                currencyOrder.FeeTotal += currencyItems.Sum(x => x.Fee);
-                currencyOrder.FeeTotalWithTax += currencyItems.Sum(x => x.FeeWithTax);
-                currencyOrder.TaxTotal += currencyItems.Sum(x => x.TaxTotal);
-            }
-
-            order.ShippingTotal = 0m;
-            order.ShippingTotalWithTax = 0m;
-            order.ShippingSubTotal = 0m;
-            order.ShippingSubTotalWithTax = 0m;
-            order.ShippingDiscountTotal = 0m;
-            order.ShippingDiscountTotalWithTax = 0m;
-
-            foreach (var (currencyCode, currencyOrder) in ordersByCurrency)
-            {
+                // Shipments
                 var currencyShipments = order.Shipments?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+                orderCart.ShippingTotal = currencyShipments.Sum(x => x.Total);
+                orderCart.ShippingTotalWithTax = currencyShipments.Sum(x => x.TotalWithTax);
+                orderCart.ShippingSubTotal = currencyShipments.Sum(x => x.Price);
+                orderCart.ShippingSubTotalWithTax = currencyShipments.Sum(x => x.PriceWithTax);
+                orderCart.ShippingDiscountTotal = currencyShipments.Sum(x => x.DiscountAmount);
+                orderCart.ShippingDiscountTotalWithTax = currencyShipments.Sum(x => x.DiscountAmountWithTax);
+                orderCart.DiscountTotal += currencyShipments.Sum(x => x.DiscountAmount);
+                orderCart.DiscountTotalWithTax += currencyShipments.Sum(x => x.DiscountAmountWithTax);
+                orderCart.FeeTotal += currencyShipments.Sum(x => x.Fee);
+                orderCart.FeeTotalWithTax += currencyShipments.Sum(x => x.FeeWithTax);
+                orderCart.TaxTotal += currencyShipments.Sum(x => x.TaxTotal);
 
-                currencyOrder.ShippingTotal = currencyShipments.Sum(x => x.Total);
-                currencyOrder.ShippingTotalWithTax = currencyShipments.Sum(x => x.TotalWithTax);
-                currencyOrder.ShippingSubTotal = currencyShipments.Sum(x => x.Price);
-                currencyOrder.ShippingSubTotalWithTax = currencyShipments.Sum(x => x.PriceWithTax);
-                currencyOrder.ShippingDiscountTotal = currencyShipments.Sum(x => x.DiscountAmount);
-                currencyOrder.ShippingDiscountTotalWithTax = currencyShipments.Sum(x => x.DiscountAmountWithTax);
-                currencyOrder.DiscountTotal += currencyShipments.Sum(x => x.DiscountAmount);
-                currencyOrder.DiscountTotalWithTax += currencyShipments.Sum(x => x.DiscountAmountWithTax);
-                currencyOrder.FeeTotal += currencyShipments.Sum(x => x.Fee);
-                currencyOrder.FeeTotalWithTax += currencyShipments.Sum(x => x.FeeWithTax);
-                currencyOrder.TaxTotal += currencyShipments.Sum(x => x.TaxTotal);
-            }
-
-            order.PaymentTotal = 0m;
-            order.PaymentTotalWithTax = 0m;
-            order.PaymentSubTotal = 0m;
-            order.PaymentSubTotalWithTax = 0m;
-            order.PaymentDiscountTotal = 0m;
-            order.PaymentDiscountTotalWithTax = 0m;
-
-            foreach (var (currencyCode, currencyOrder) in ordersByCurrency)
-            {
+                // Payments
                 var currencyPayments = order.InPayments?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+                orderCart.PaymentTotal = currencyPayments.Sum(x => x.Total);
+                orderCart.PaymentTotalWithTax = currencyPayments.Sum(x => x.TotalWithTax);
+                orderCart.PaymentSubTotal = currencyPayments.Sum(x => x.Price);
+                orderCart.PaymentSubTotalWithTax = currencyPayments.Sum(x => x.PriceWithTax);
+                orderCart.PaymentDiscountTotal = currencyPayments.Sum(x => x.DiscountAmount);
+                orderCart.PaymentDiscountTotalWithTax = currencyPayments.Sum(x => x.DiscountAmountWithTax);
+                orderCart.DiscountTotal += currencyPayments.Sum(x => x.DiscountAmount);
+                orderCart.DiscountTotalWithTax += currencyPayments.Sum(x => x.DiscountAmountWithTax);
+                orderCart.TaxTotal += currencyPayments.Sum(x => x.TaxTotal);
 
-                currencyOrder.PaymentTotal = currencyPayments.Sum(x => x.Total);
-                currencyOrder.PaymentTotalWithTax = currencyPayments.Sum(x => x.TotalWithTax);
-                currencyOrder.PaymentSubTotal = currencyPayments.Sum(x => x.Price);
-                currencyOrder.PaymentSubTotalWithTax = currencyPayments.Sum(x => x.PriceWithTax);
-                currencyOrder.PaymentDiscountTotal = currencyPayments.Sum(x => x.DiscountAmount);
-                currencyOrder.PaymentDiscountTotalWithTax = currencyPayments.Sum(x => x.DiscountAmountWithTax);
-                currencyOrder.DiscountTotal += currencyPayments.Sum(x => x.DiscountAmount);
-                currencyOrder.DiscountTotalWithTax += currencyPayments.Sum(x => x.DiscountAmountWithTax);
-                currencyOrder.TaxTotal += currencyPayments.Sum(x => x.TaxTotal);
-            }
-
-            var allCurrencies = _currencyService.GetAllCurrenciesAsync().GetAwaiter().GetResult().ToList();
-
-            foreach (var orderCart in ordersByCurrency.Select(x => x.Value))
-            {
                 var taxFactor = 1 + orderCart.TaxPercentRate;
                 orderCart.FeeWithTax = orderCart.Fee * taxFactor;
                 orderCart.FeeTotalWithTax = orderCart.FeeTotal * taxFactor;
@@ -160,7 +131,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 orderCart.TaxTotal -= orderCart.DiscountAmount * orderCart.TaxPercentRate;
 
                 //Need to round all order totals
-                var currency = allCurrencies.First(c => c.Code == orderCart.Currency);
+                var currency = GetCurrency(allCurrencies, orderCart.Currency);
                 orderCart.SubTotal = currency.RoundingPolicy.RoundMoney(orderCart.SubTotal, currency);
                 orderCart.SubTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.SubTotalWithTax, currency);
                 orderCart.SubTotalDiscount = currency.RoundingPolicy.RoundMoney(orderCart.SubTotalDiscount, currency);
@@ -201,6 +172,17 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             }).ToList();
         }
 
+        protected virtual IList<Currency> GetAllCurrencies()
+        {
+            return _currencyService.GetAllCurrenciesAsync().GetAwaiter().GetResult().ToList();
+        }
+
+        protected virtual Currency GetCurrency(IList<Currency> currencies, string currencyCode)
+        {
+            return currencies.First(c => c.Code == currencyCode);
+        }
+
+        [Obsolete("No longer used. Use GetAllCurrencies() and GetCurrency(IList<Currency>, string) instead.", false)]
         protected virtual async Task<Currency> GetCurrency(string orderCurrencyName)
         {
             var currencies = await _currencyService.GetAllCurrenciesAsync();

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -57,7 +57,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 }
             }
 
-            var ordersByCurrency = new Dictionary<string, CustomerOrder>
+            var ordersByCurrency = new Dictionary<string, CustomerOrder>(StringComparer.OrdinalIgnoreCase)
             {
                 { order.Currency, order }
             };

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using VirtoCommerce.CoreModule.Core.Currency;
@@ -61,6 +62,22 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             order.FeeTotal = order.Fee;
             order.TaxTotal = 0m;
 
+            var ordersByCurrency = new Dictionary<string, CustomerOrder>
+            {
+                { order.Currency, order }
+            };
+
+            var currencyCodes = (order.Items?.Select(x => x.Currency) ?? [])
+                .Concat(order.Shipments?.Select(x => x.Currency) ?? [])
+                .Concat(order.InPayments?.Select(x => x.Currency) ?? [])
+                .Where(x => !string.IsNullOrEmpty(x))
+                .Distinct();
+
+            foreach (var currencyCode in currencyCodes)
+            {
+                AddCustomerOrderByCurrency(ordersByCurrency, currencyCode);
+            }
+
             order.SubTotal = 0m;
             order.SubTotalWithTax = 0m;
             order.SubTotalTaxTotal = 0m;
@@ -68,18 +85,20 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             order.SubTotalDiscountWithTax = 0m;
             order.FeeTotalWithTax = 0m;
 
-            if (order.Items != null)
+            foreach (var (currencyCode, currencyOrder) in ordersByCurrency)
             {
-                order.SubTotal = order.Items.Sum(x => x.ListTotal);
-                order.SubTotalWithTax = order.Items.Sum(x => x.ListTotalWithTax);
-                order.SubTotalTaxTotal += order.Items.Sum(x => x.TaxTotal);
-                order.SubTotalDiscount = order.Items.Sum(x => x.DiscountTotal);
-                order.SubTotalDiscountWithTax = order.Items.Sum(x => x.DiscountTotalWithTax);
-                order.DiscountTotal += order.Items.Sum(x => x.DiscountTotal);
-                order.DiscountTotalWithTax += order.Items.Sum(x => x.DiscountTotalWithTax);
-                order.FeeTotal += order.Items.Sum(x => x.Fee);
-                order.FeeTotalWithTax += order.Items.Sum(x => x.FeeWithTax);
-                order.TaxTotal += order.Items.Sum(x => x.TaxTotal);
+                var currencyItems = order.Items?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+
+                currencyOrder.SubTotal = currencyItems.Sum(x => x.ListTotal);
+                currencyOrder.SubTotalWithTax = currencyItems.Sum(x => x.ListTotalWithTax);
+                currencyOrder.SubTotalTaxTotal = currencyItems.Sum(x => x.TaxTotal);
+                currencyOrder.SubTotalDiscount = currencyItems.Sum(x => x.DiscountTotal);
+                currencyOrder.SubTotalDiscountWithTax = currencyItems.Sum(x => x.DiscountTotalWithTax);
+                currencyOrder.DiscountTotal += currencyItems.Sum(x => x.DiscountTotal);
+                currencyOrder.DiscountTotalWithTax += currencyItems.Sum(x => x.DiscountTotalWithTax);
+                currencyOrder.FeeTotal += currencyItems.Sum(x => x.Fee);
+                currencyOrder.FeeTotalWithTax += currencyItems.Sum(x => x.FeeWithTax);
+                currencyOrder.TaxTotal += currencyItems.Sum(x => x.TaxTotal);
             }
 
             order.ShippingTotal = 0m;
@@ -89,19 +108,21 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             order.ShippingDiscountTotal = 0m;
             order.ShippingDiscountTotalWithTax = 0m;
 
-            if (order.Shipments != null)
+            foreach (var (currencyCode, currencyOrder) in ordersByCurrency)
             {
-                order.ShippingTotal = order.Shipments.Sum(x => x.Total);
-                order.ShippingTotalWithTax = order.Shipments.Sum(x => x.TotalWithTax);
-                order.ShippingSubTotal = order.Shipments.Sum(x => x.Price);
-                order.ShippingSubTotalWithTax = order.Shipments.Sum(x => x.PriceWithTax);
-                order.ShippingDiscountTotal = order.Shipments.Sum(x => x.DiscountAmount);
-                order.ShippingDiscountTotalWithTax = order.Shipments.Sum(x => x.DiscountAmountWithTax);
-                order.DiscountTotal += order.Shipments.Sum(x => x.DiscountAmount);
-                order.DiscountTotalWithTax += order.Shipments.Sum(x => x.DiscountAmountWithTax);
-                order.FeeTotal += order.Shipments.Sum(x => x.Fee);
-                order.FeeTotalWithTax += order.Shipments.Sum(x => x.FeeWithTax);
-                order.TaxTotal += order.Shipments.Sum(x => x.TaxTotal);
+                var currencyShipments = order.Shipments?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+
+                currencyOrder.ShippingTotal = currencyShipments.Sum(x => x.Total);
+                currencyOrder.ShippingTotalWithTax = currencyShipments.Sum(x => x.TotalWithTax);
+                currencyOrder.ShippingSubTotal = currencyShipments.Sum(x => x.Price);
+                currencyOrder.ShippingSubTotalWithTax = currencyShipments.Sum(x => x.PriceWithTax);
+                currencyOrder.ShippingDiscountTotal = currencyShipments.Sum(x => x.DiscountAmount);
+                currencyOrder.ShippingDiscountTotalWithTax = currencyShipments.Sum(x => x.DiscountAmountWithTax);
+                currencyOrder.DiscountTotal += currencyShipments.Sum(x => x.DiscountAmount);
+                currencyOrder.DiscountTotalWithTax += currencyShipments.Sum(x => x.DiscountAmountWithTax);
+                currencyOrder.FeeTotal += currencyShipments.Sum(x => x.Fee);
+                currencyOrder.FeeTotalWithTax += currencyShipments.Sum(x => x.FeeWithTax);
+                currencyOrder.TaxTotal += currencyShipments.Sum(x => x.TaxTotal);
             }
 
             order.PaymentTotal = 0m;
@@ -111,53 +132,73 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             order.PaymentDiscountTotal = 0m;
             order.PaymentDiscountTotalWithTax = 0m;
 
-            if (order.InPayments != null)
+            foreach (var (currencyCode, currencyOrder) in ordersByCurrency)
             {
-                order.PaymentTotal = order.InPayments.Sum(x => x.Total);
-                order.PaymentTotalWithTax = order.InPayments.Sum(x => x.TotalWithTax);
-                order.PaymentSubTotal = order.InPayments.Sum(x => x.Price);
-                order.PaymentSubTotalWithTax = order.InPayments.Sum(x => x.PriceWithTax);
-                order.PaymentDiscountTotal = order.InPayments.Sum(x => x.DiscountAmount);
-                order.PaymentDiscountTotalWithTax = order.InPayments.Sum(x => x.DiscountAmountWithTax);
-                order.DiscountTotal += order.InPayments.Sum(x => x.DiscountAmount);
-                order.DiscountTotalWithTax += order.InPayments.Sum(x => x.DiscountAmountWithTax);
-                order.TaxTotal += order.InPayments.Sum(x => x.TaxTotal);
+                var currencyPayments = order.InPayments?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+
+                currencyOrder.PaymentTotal = currencyPayments.Sum(x => x.Total);
+                currencyOrder.PaymentTotalWithTax = currencyPayments.Sum(x => x.TotalWithTax);
+                currencyOrder.PaymentSubTotal = currencyPayments.Sum(x => x.Price);
+                currencyOrder.PaymentSubTotalWithTax = currencyPayments.Sum(x => x.PriceWithTax);
+                currencyOrder.PaymentDiscountTotal = currencyPayments.Sum(x => x.DiscountAmount);
+                currencyOrder.PaymentDiscountTotalWithTax = currencyPayments.Sum(x => x.DiscountAmountWithTax);
+                currencyOrder.DiscountTotal += currencyPayments.Sum(x => x.DiscountAmount);
+                currencyOrder.DiscountTotalWithTax += currencyPayments.Sum(x => x.DiscountAmountWithTax);
+                currencyOrder.TaxTotal += currencyPayments.Sum(x => x.TaxTotal);
             }
 
-            var taxFactor = 1 + order.TaxPercentRate;
-            order.FeeWithTax = order.Fee * taxFactor;
-            order.FeeTotalWithTax = order.FeeTotal * taxFactor;
-            order.DiscountTotal += order.DiscountAmount;
-            order.DiscountTotalWithTax += order.DiscountAmount * taxFactor;
-            //Subtract from order tax total self discount tax amount
-            order.TaxTotal -= order.DiscountAmount * order.TaxPercentRate;
+            var allCurrencies = _currencyService.GetAllCurrenciesAsync().GetAwaiter().GetResult().ToList();
 
-            //Need to round all order totals
-            var currency = GetCurrency(order.Currency).GetAwaiter().GetResult();
-            order.SubTotal = currency.RoundingPolicy.RoundMoney(order.SubTotal, currency);
-            order.SubTotalWithTax = currency.RoundingPolicy.RoundMoney(order.SubTotalWithTax, currency);
-            order.SubTotalDiscount = currency.RoundingPolicy.RoundMoney(order.SubTotalDiscount, currency);
-            order.SubTotalDiscountWithTax = currency.RoundingPolicy.RoundMoney(order.SubTotalDiscountWithTax, currency);
-            order.TaxTotal = currency.RoundingPolicy.RoundMoney(order.TaxTotal, currency);
-            order.DiscountTotal = currency.RoundingPolicy.RoundMoney(order.DiscountTotal, currency);
-            order.DiscountTotalWithTax = currency.RoundingPolicy.RoundMoney(order.DiscountTotalWithTax, currency);
-            order.Fee = currency.RoundingPolicy.RoundMoney(order.Fee, currency);
-            order.FeeWithTax = currency.RoundingPolicy.RoundMoney(order.FeeWithTax, currency);
-            order.FeeTotal = currency.RoundingPolicy.RoundMoney(order.FeeTotal, currency);
-            order.FeeTotalWithTax = currency.RoundingPolicy.RoundMoney(order.FeeTotalWithTax, currency);
-            order.ShippingTotal = currency.RoundingPolicy.RoundMoney(order.ShippingTotal, currency);
-            order.ShippingTotalWithTax = currency.RoundingPolicy.RoundMoney(order.ShippingTotalWithTax, currency);
-            order.ShippingSubTotal = currency.RoundingPolicy.RoundMoney(order.ShippingSubTotal, currency);
-            order.ShippingSubTotalWithTax = currency.RoundingPolicy.RoundMoney(order.ShippingSubTotalWithTax, currency);
-            order.PaymentTotal = currency.RoundingPolicy.RoundMoney(order.PaymentTotal, currency);
-            order.PaymentTotalWithTax = currency.RoundingPolicy.RoundMoney(order.PaymentTotalWithTax, currency);
-            order.PaymentSubTotal = currency.RoundingPolicy.RoundMoney(order.PaymentSubTotal, currency);
-            order.PaymentSubTotalWithTax = currency.RoundingPolicy.RoundMoney(order.PaymentSubTotalWithTax, currency);
-            order.PaymentDiscountTotal = currency.RoundingPolicy.RoundMoney(order.PaymentDiscountTotal, currency);
-            order.PaymentDiscountTotalWithTax = currency.RoundingPolicy.RoundMoney(order.PaymentDiscountTotalWithTax, currency);
+            foreach (var orderCart in ordersByCurrency.Select(x => x.Value))
+            {
+                var taxFactor = 1 + orderCart.TaxPercentRate;
+                orderCart.FeeWithTax = orderCart.Fee * taxFactor;
+                orderCart.FeeTotalWithTax = orderCart.FeeTotal * taxFactor;
+                orderCart.DiscountTotal += orderCart.DiscountAmount;
+                orderCart.DiscountTotalWithTax += orderCart.DiscountAmount * taxFactor;
+                //Subtract from order tax total self discount tax amount
+                orderCart.TaxTotal -= orderCart.DiscountAmount * orderCart.TaxPercentRate;
 
-            order.Total = order.SubTotal + order.ShippingSubTotal + order.TaxTotal + order.PaymentSubTotal + order.FeeTotal - order.DiscountTotal;
-            order.Sum = order.Total;
+                //Need to round all order totals
+                var currency = allCurrencies.First(c => c.Code == orderCart.Currency);
+                orderCart.SubTotal = currency.RoundingPolicy.RoundMoney(orderCart.SubTotal, currency);
+                orderCart.SubTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.SubTotalWithTax, currency);
+                orderCart.SubTotalDiscount = currency.RoundingPolicy.RoundMoney(orderCart.SubTotalDiscount, currency);
+                orderCart.SubTotalDiscountWithTax = currency.RoundingPolicy.RoundMoney(orderCart.SubTotalDiscountWithTax, currency);
+                orderCart.TaxTotal = currency.RoundingPolicy.RoundMoney(orderCart.TaxTotal, currency);
+                orderCart.DiscountTotal = currency.RoundingPolicy.RoundMoney(orderCart.DiscountTotal, currency);
+                orderCart.DiscountTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.DiscountTotalWithTax, currency);
+                orderCart.Fee = currency.RoundingPolicy.RoundMoney(orderCart.Fee, currency);
+                orderCart.FeeWithTax = currency.RoundingPolicy.RoundMoney(orderCart.FeeWithTax, currency);
+                orderCart.FeeTotal = currency.RoundingPolicy.RoundMoney(orderCart.FeeTotal, currency);
+                orderCart.FeeTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.FeeTotalWithTax, currency);
+                orderCart.ShippingTotal = currency.RoundingPolicy.RoundMoney(orderCart.ShippingTotal, currency);
+                orderCart.ShippingTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.ShippingTotalWithTax, currency);
+                orderCart.ShippingSubTotal = currency.RoundingPolicy.RoundMoney(orderCart.ShippingSubTotal, currency);
+                orderCart.ShippingSubTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.ShippingSubTotalWithTax, currency);
+                orderCart.PaymentTotal = currency.RoundingPolicy.RoundMoney(orderCart.PaymentTotal, currency);
+                orderCart.PaymentTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.PaymentTotalWithTax, currency);
+                orderCart.PaymentSubTotal = currency.RoundingPolicy.RoundMoney(orderCart.PaymentSubTotal, currency);
+                orderCart.PaymentSubTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.PaymentSubTotalWithTax, currency);
+                orderCart.PaymentDiscountTotal = currency.RoundingPolicy.RoundMoney(orderCart.PaymentDiscountTotal, currency);
+                orderCart.PaymentDiscountTotalWithTax = currency.RoundingPolicy.RoundMoney(orderCart.PaymentDiscountTotalWithTax, currency);
+
+                orderCart.Total = orderCart.SubTotal + orderCart.ShippingSubTotal + orderCart.TaxTotal + orderCart.PaymentSubTotal + orderCart.FeeTotal - orderCart.DiscountTotal;
+                orderCart.Sum = orderCart.Total;
+            }
+
+            order.OrderTotals = ordersByCurrency.Select(x =>
+            {
+                var cartTotal = AbstractTypeFactory<OrderTotal>.TryCreateInstance();
+
+                cartTotal.CurrencyCode = x.Value.Currency;
+                cartTotal.Total = x.Value.Total;
+                cartTotal.SubTotal = x.Value.SubTotal;
+                cartTotal.TaxTotal = x.Value.TaxTotal;
+                cartTotal.DiscountTotal = x.Value.DiscountTotal;
+
+                return cartTotal;
+            }).ToList();
         }
 
         protected virtual async Task<Currency> GetCurrency(string orderCurrencyName)
@@ -221,6 +262,18 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             lineItem.FeeWithTax = lineItem.Fee * taxFactor;
 
             lineItem.TaxTotal = lineItem.ExtendedPrice * lineItem.TaxPercentRate;
+        }
+
+        private static CustomerOrder AddCustomerOrderByCurrency(Dictionary<string, CustomerOrder> orderByCurrency, string currencyCode)
+        {
+            if (!orderByCurrency.TryGetValue(currencyCode, out var currencyOrder))
+            {
+                currencyOrder = AbstractTypeFactory<CustomerOrder>.TryCreateInstance();
+                currencyOrder.Currency = currencyCode;
+                orderByCurrency.Add(currencyCode, currencyOrder);
+            }
+
+            return currencyOrder;
         }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -182,7 +182,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
             return currencies.First(c => c.Code == currencyCode);
         }
 
-        [Obsolete("No longer used. Use GetAllCurrencies() and GetCurrency(IList<Currency>, string) instead.", false)]
+        [Obsolete("No longer used. Use GetAllCurrencies() and GetCurrency(IList<Currency>, string) instead.", false, DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         protected virtual async Task<Currency> GetCurrency(string orderCurrencyName)
         {
             var currencies = await _currencyService.GetAllCurrenciesAsync();

--- a/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Services/DefaultCustomerOrderTotalsCalculator.cs
@@ -84,7 +84,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 orderCart.TaxTotal = 0m;
 
                 // Line items
-                var currencyItems = order.Items?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+                var currencyItems = order.Items?.Where(x => x.Currency.EqualsIgnoreCase(currencyCode)).ToList() ?? [];
                 orderCart.SubTotal = currencyItems.Sum(x => x.ListTotal);
                 orderCart.SubTotalWithTax = currencyItems.Sum(x => x.ListTotalWithTax);
                 orderCart.SubTotalTaxTotal = currencyItems.Sum(x => x.TaxTotal);
@@ -97,7 +97,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 orderCart.TaxTotal += currencyItems.Sum(x => x.TaxTotal);
 
                 // Shipments
-                var currencyShipments = order.Shipments?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+                var currencyShipments = order.Shipments?.Where(x => x.Currency.EqualsIgnoreCase(currencyCode)).ToList() ?? [];
                 orderCart.ShippingTotal = currencyShipments.Sum(x => x.Total);
                 orderCart.ShippingTotalWithTax = currencyShipments.Sum(x => x.TotalWithTax);
                 orderCart.ShippingSubTotal = currencyShipments.Sum(x => x.Price);
@@ -111,7 +111,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
                 orderCart.TaxTotal += currencyShipments.Sum(x => x.TaxTotal);
 
                 // Payments
-                var currencyPayments = order.InPayments?.Where(x => x.Currency == currencyCode).ToList() ?? [];
+                var currencyPayments = order.InPayments?.Where(x => x.Currency.EqualsIgnoreCase(currencyCode)).ToList() ?? [];
                 orderCart.PaymentTotal = currencyPayments.Sum(x => x.Total);
                 orderCart.PaymentTotalWithTax = currencyPayments.Sum(x => x.TotalWithTax);
                 orderCart.PaymentSubTotal = currencyPayments.Sum(x => x.Price);
@@ -179,7 +179,7 @@ namespace VirtoCommerce.OrdersModule.Data.Services
 
         protected virtual Currency GetCurrency(IList<Currency> currencies, string currencyCode)
         {
-            return currencies.First(c => c.Code == currencyCode);
+            return currencies.First(c => c.Code.EqualsIgnoreCase(currencyCode));
         }
 
         protected virtual async Task<Currency> GetCurrency(string orderCurrencyName)

--- a/src/VirtoCommerce.OrdersModule.Web/Content/css/orderModule.css
+++ b/src/VirtoCommerce.OrdersModule.Web/Content/css/orderModule.css
@@ -29,6 +29,17 @@
     margin: 0 0 0 10px;
 }
 
+/* Wider blade for customer order items  */
+.blade .blade-content.__xxlarge-wider {
+  min-width: 980px;
+  width: 980px;
+}
+
+.blade .blade-content.__xxlarge-wider .inner-block {
+  min-width: 100%;
+  width: 100%;
+}
+
 /* Customer order items (line items blade) */
 .vc-order .customer-order-items .order-items-summary {
     border-radius: 4px;

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/de.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/de.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Zwischensumme",
           "discount-total": "Rabatt",
           "tax-total": "Steuer",
-          "fee-total": "Gebühr"
+          "fee-total": "Gebühr",
+          "currency": "Währung"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/en.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/en.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Subtotal",
           "discount-total": "Discount",
           "tax-total": "Tax",
-          "fee-total": "Fee"
+          "fee-total": "Fee",
+          "currency": "Currency"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/es.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/es.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Subtotal",
           "discount-total": "Descuento",
           "tax-total": "Impuesto",
-          "fee-total": "Tarifa"
+          "fee-total": "Tarifa",
+          "currency": "Moneda"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/fr.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/fr.VirtoCommerce.Orders.json
@@ -43,7 +43,8 @@
           "sub-total": "Sous-total",
           "discount-total": "Remise",
           "tax-total": "Taxe",
-          "fee-total": "Frais"
+          "fee-total": "Frais",
+          "currency": "Devise"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/it.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/it.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Subtotale",
           "discount-total": "Sconto",
           "tax-total": "Tasse",
-          "fee-total": "Commissioni"
+          "fee-total": "Commissioni",
+          "currency": "Valuta"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/ja.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/ja.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "小計",
           "discount-total": "割引",
           "tax-total": "税",
-          "fee-total": "手数料"
+          "fee-total": "手数料",
+          "currency": "通貨"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/pl.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/pl.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Suma częściowa",
           "discount-total": "Rabat",
           "tax-total": "Podatek",
-          "fee-total": "Opłata"
+          "fee-total": "Opłata",
+          "currency": "Waluta"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/pt.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/pt.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Subtotal",
           "discount-total": "Desconto",
           "tax-total": "Imposto",
-          "fee-total": "Taxa"
+          "fee-total": "Taxa",
+          "currency": "Moeda"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/ru.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/ru.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "Подытог",
           "discount-total": "Скидка",
           "tax-total": "Налог",
-          "fee-total": "Комиссия"
+          "fee-total": "Комиссия",
+          "currency": "Валюта"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Localizations/zh.VirtoCommerce.Orders.json
+++ b/src/VirtoCommerce.OrdersModule.Web/Localizations/zh.VirtoCommerce.Orders.json
@@ -42,7 +42,8 @@
           "sub-total": "小计",
           "discount-total": "折扣",
           "tax-total": "税",
-          "fee-total": "费用"
+          "fee-total": "费用",
+          "currency": "货币"
         }
       },
       "customerOrder-item-detail": {

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
@@ -23,6 +23,24 @@
               </div>
             </div>
 
+            <!-- Summary for non-primary currencies -->
+            <div class="order-items-summary"
+                 ng-repeat="orderTotal in blade.currentEntity.orderTotals"
+                 ng-if="orderTotal.currencyCode !== blade.currentEntity.currency">
+              <div class="order-items-summary__item">
+                <span class="order-items-summary__value">{{ orderTotal.subTotal | currency:orderTotal.currencyCode | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+              <div class="order-items-summary__item">
+                <span class="order-items-summary__value">{{ orderTotal.discountTotal | currency:orderTotal.currencyCode | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+              <div class="order-items-summary__item">
+                <span class="order-items-summary__value">{{ orderTotal.taxTotal | currency:orderTotal.currencyCode | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+              <div class="order-items-summary__item __total">
+                <span class="order-items-summary__value">{{ orderTotal.total | currency:orderTotal.currencyCode | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+            </div>
+
             <div class="table-wrapper">
                 <table class="table __line-items">
                     <thead>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
@@ -34,7 +34,7 @@
                           </label>
                         </th>
                         <th class="table-col __proudct-img">{{ 'orders.blades.customerOrder-items.labels.item' | translate }}</th>
-                        <th class="table-col">{{ 'Currency' | translate }}</th>
+                        <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.currency' | translate }}</th>
                         <th class="table-col __status">{{ 'orders.blades.customerOrder-items.labels.status' | translate }}</th>
                         <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.quantity' | translate }}</th>
                         <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.price' | translate }}</th>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
@@ -1,4 +1,4 @@
-<div class="blade-content vc-order __xxlarge-wide">
+<div class="blade-content vc-order __xxlarge-wider">
     <div class="blade-inner customer-order-items">
         <div class="inner-block">
             <form name="orderForm" novalidate></form>

--- a/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
+++ b/src/VirtoCommerce.OrdersModule.Web/Scripts/blades/customerOrder-items.tpl.html
@@ -5,103 +5,107 @@
 
             <!-- Summary moved above grid (no overlay; faster scanning) -->
             <div class="order-items-summary" ng-if="blade.currentEntity">
-                <div class="order-items-summary__item">
-                    <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.sub-total' | translate }}</span>
-                    <span class="order-items-summary__value">{{blade.currentEntity.subTotal | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
-                </div>
-                <div class="order-items-summary__item">
-                    <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.discount-total' | translate }}</span>
-                    <span class="order-items-summary__value">{{blade.currentEntity.subTotalDiscount | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
-                </div>
-                <div class="order-items-summary__item">
-                    <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.tax-total' | translate }}</span>
-                    <span class="order-items-summary__value">{{ blade.currentEntity.subTotalTaxTotal | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
-                </div>
-                <div class="order-items-summary__item __total">
-                    <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.total' | translate }}</span>
-                    <span class="order-items-summary__value">{{ (blade.currentEntity.subTotalWithTax - blade.currentEntity.subTotalDiscountWithTax) | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
-                </div>
+              <div class="order-items-summary__item">
+                <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.sub-total' | translate }}</span>
+                <span class="order-items-summary__value">{{blade.currentEntity.subTotal | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+              <div class="order-items-summary__item">
+                <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.discount-total' | translate }}</span>
+                <span class="order-items-summary__value">{{blade.currentEntity.subTotalDiscount | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+              <div class="order-items-summary__item">
+                <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.tax-total' | translate }}</span>
+                <span class="order-items-summary__value">{{ blade.currentEntity.subTotalTaxTotal | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
+              </div>
+              <div class="order-items-summary__item __total">
+                <span class="order-items-summary__label">{{ 'orders.blades.customerOrder-items.labels.total' | translate }}</span>
+                <span class="order-items-summary__value">{{ (blade.currentEntity.subTotalWithTax - blade.currentEntity.subTotalDiscountWithTax) | currency:blade.currentEntity.currency | showPrice:blade.isVisiblePrices}}</span>
+              </div>
             </div>
 
             <div class="table-wrapper">
                 <table class="table __line-items">
                     <thead>
-                        <tr>
-                            <th class="table-col __product-control">
-                                <label class="form-control __checkbox">
-                                    <input type="checkbox" ng-model="blade.selectedAll" ng-change="checkAll(blade.selectedAll)" />
-                                    <span class="check"></span>
-                                </label>
-                            </th>
-                            <th class="table-col __proudct-img">{{ 'orders.blades.customerOrder-items.labels.item' | translate }}</th>
-                            <th class="table-col __status">{{ 'orders.blades.customerOrder-items.labels.status' | translate }}</th>
-                            <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.quantity' | translate }}</th>
-                            <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.price' | translate }}</th>
-                            <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.discount' | translate }}</th>
-                            <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.tax' | translate }}</th>
-                            <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.total' | translate }}</th>
-                        </tr>
+                      <tr>
+                        <th class="table-col __product-control">
+                          <label class="form-control __checkbox">
+                            <input type="checkbox" ng-model="blade.selectedAll" ng-change="checkAll(blade.selectedAll)" />
+                            <span class="check"></span>
+                          </label>
+                        </th>
+                        <th class="table-col __proudct-img">{{ 'orders.blades.customerOrder-items.labels.item' | translate }}</th>
+                        <th class="table-col">{{ 'Currency' | translate }}</th>
+                        <th class="table-col __status">{{ 'orders.blades.customerOrder-items.labels.status' | translate }}</th>
+                        <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.quantity' | translate }}</th>
+                        <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.price' | translate }}</th>
+                        <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.discount' | translate }}</th>
+                        <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.tax' | translate }}</th>
+                        <th class="table-col">{{ 'orders.blades.customerOrder-items.labels.total' | translate }}</th>
+                      </tr>
                     </thead>
                     <tbody>
-                        <tr class="table-item" ng-repeat="data in blade.currentEntity.items track by (data.id || $index)" ng-class="{'__selected': $index === blade.selectedNodeId}" ng-click="openLineItemDetail(data, $index)">
-                            <td class="table-col">
-                                <label class="form-control __checkbox" ng-click="$event.stopPropagation()">
-                                    <input type="checkbox" ng-model="data.selected" ng-change="updateSelectedAll()">
-                                    <span class="check"></span>
-                                </label>
-                            </td>
-                            <td class="table-col">
-                                <div class="order-items__item">
-                                    <div class="product-img">
-                                        <img class="product-img__img"
-                                             ng-if="data.imageUrl"
-                                             ng-src="{{data.imageUrl}}"
-                                             alt=""
-                                             onerror="this.closest('.product-img').classList.add('__no-img'); this.remove();">
-                                        <i class="table-ico fa fa-image product-img__fallback" aria-hidden="true" ng-if="data.imageUrl"></i>
-                                        <i class="table-ico fa fa-image" aria-hidden="true" ng-if="!data.imageUrl"></i>
-                                    </div>
-                                    <div class="order-items__item-info">
-                                        <div class="order-items__item-name" ng-attr-title="{{data.name}}">
-                                            <span class="order-items__item-name-text">{{data.name}}</span>
-                                        </div>
-                                        <div class="order-items__item-sku" ng-if="data.sku">{{data.sku}}</div>
-                                        <div class="order-items__item-comment" ng-if="data.comment">{{ data.comment }}</div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class="table-col __status">
-                                <div class="form-input __inline" ng-click="$event.stopPropagation()">
-                                    <va-setting-value-select placeholder="'orders.blades.customerOrder-detail.placeholders.status' | translate"
-                                                             setting="'OrderLineItem.Statuses'"
-                                                             ng-model="data.status"
-                                                             allow-clear="true"></va-setting-value-select>
-                                </div>
-                            </td>
-                            <td class="table-col">
-                                <div class="form-input __mini __inline">
-                                    <div class="form-input __mini __number" ng-click="$event.stopPropagation()">
-                                        <input smart-float num-type="integer" required ng-model="data.quantity" ng-model-options="{ updateOn: 'blur' }" ng-change="blade.recalculateFn()" id="quantity{{$index}}" focus-on="quantity{{$index}}">
-                                    </div>
-                                </div>
-                            </td>
-                            <td class="table-col">
-                                <div class="form-input __mini" ng-click="$event.stopPropagation()">
-                                    <input money mask-money="!blade.isVisiblePrices" required ng-model="data.price" ng-model-options="{ updateOn: 'blur' }" ng-change="blade.recalculateFn()" id="price{{$index}}" focus-on="price{{$index}}">
-                                </div>
-                            </td>
-                            <td class="table-col">
-                                <div class="form-input __mini __inline" ng-click="$event.stopPropagation()">
-                                    <input money mask-money="!blade.isVisiblePrices" required ng-model="data.discountAmount" ng-model-options="{ updateOn: 'blur' }" ng-change="blade.recalculateFn()" id="discountAmount{{$index}}" focus-on="discountAmount{{$index}}">
-                                </div>
-                            </td>
-                            <td class="table-col">
-                                <span class="list-price">{{data.taxTotal | currency:'' | showPrice:blade.isVisiblePrices}}</span>
-                            </td>
-                            <td class="table-col __total">
-                                <span class="list-price">{{data.extendedPriceWithTax | currency:'' | showPrice:blade.isVisiblePrices}}</span>
-                            </td>
-                        </tr>
+                      <tr class="table-item" ng-repeat="data in blade.currentEntity.items track by (data.id || $index)" ng-class="{'__selected': $index === blade.selectedNodeId}" ng-click="openLineItemDetail(data, $index)">
+                        <td class="table-col">
+                          <label class="form-control __checkbox" ng-click="$event.stopPropagation()">
+                            <input type="checkbox" ng-model="data.selected" ng-change="updateSelectedAll()">
+                            <span class="check"></span>
+                          </label>
+                        </td>
+                        <td class="table-col">
+                          <div class="order-items__item">
+                            <div class="product-img">
+                              <img class="product-img__img"
+                                   ng-if="data.imageUrl"
+                                   ng-src="{{data.imageUrl}}"
+                                   alt=""
+                                   onerror="this.closest('.product-img').classList.add('__no-img'); this.remove();">
+                              <i class="table-ico fa fa-image product-img__fallback" aria-hidden="true" ng-if="data.imageUrl"></i>
+                              <i class="table-ico fa fa-image" aria-hidden="true" ng-if="!data.imageUrl"></i>
+                            </div>
+                            <div class="order-items__item-info">
+                              <div class="order-items__item-name" ng-attr-title="{{data.name}}">
+                                <span class="order-items__item-name-text">{{data.name}}</span>
+                              </div>
+                              <div class="order-items__item-sku" ng-if="data.sku">{{data.sku}}</div>
+                              <div class="order-items__item-comment" ng-if="data.comment">{{ data.comment }}</div>
+                            </div>
+                          </div>
+                        </td>
+                        <td class="table-col">
+                          <span>{{data.currency}}</span>
+                        </td>
+                        <td class="table-col __status">
+                          <div class="form-input __inline" ng-click="$event.stopPropagation()">
+                            <va-setting-value-select placeholder="'orders.blades.customerOrder-detail.placeholders.status' | translate"
+                                                     setting="'OrderLineItem.Statuses'"
+                                                     ng-model="data.status"
+                                                     allow-clear="true"></va-setting-value-select>
+                          </div>
+                        </td>
+                        <td class="table-col">
+                          <div class="form-input __mini __inline">
+                            <div class="form-input __mini __number" ng-click="$event.stopPropagation()">
+                              <input smart-float num-type="integer" required ng-model="data.quantity" ng-model-options="{ updateOn: 'blur' }" ng-change="blade.recalculateFn()" id="quantity{{$index}}" focus-on="quantity{{$index}}">
+                            </div>
+                          </div>
+                        </td>
+                        <td class="table-col">
+                          <div class="form-input __mini" ng-click="$event.stopPropagation()">
+                            <input money mask-money="!blade.isVisiblePrices" required ng-model="data.price" ng-model-options="{ updateOn: 'blur' }" ng-change="blade.recalculateFn()" id="price{{$index}}" focus-on="price{{$index}}">
+                          </div>
+                        </td>
+                        <td class="table-col">
+                          <div class="form-input __mini __inline" ng-click="$event.stopPropagation()">
+                            <input money mask-money="!blade.isVisiblePrices" required ng-model="data.discountAmount" ng-model-options="{ updateOn: 'blur' }" ng-change="blade.recalculateFn()" id="discountAmount{{$index}}" focus-on="discountAmount{{$index}}">
+                          </div>
+                        </td>
+                        <td class="table-col">
+                          <span class="list-price">{{data.taxTotal | currency:'' | showPrice:blade.isVisiblePrices}}</span>
+                        </td>
+                        <td class="table-col __total">
+                          <span class="list-price">{{data.extendedPriceWithTax | currency:'' | showPrice:blade.isVisiblePrices}}</span>
+                        </td>
+                      </tr>
                     </tbody>
                 </table>
             </div>

--- a/tests/VirtoCommerce.OrdersModule.Tests/OrderTotalsCalculationTest.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/OrderTotalsCalculationTest.cs
@@ -47,14 +47,16 @@ namespace VirtoCommerce.OrdersModule.Tests
                 Price = listPrice,
                 DiscountAmount = discountAmount,
                 Quantity = quantity,
+                Currency = "USD",
             };
 
             var order = new CustomerOrder
             {
                 Items = [lineItem],
+                Currency = "USD",
             };
 
-            var currency = new Currency(new Language("en-US"), code: null)
+            var currency = new Currency(new Language("en-US"), code: "USD")
             {
                 MidpointRounding = midpointRounding.ToString(),
                 RoundingPolicy = new DefaultMoneyRoundingPolicy()
@@ -85,23 +87,24 @@ namespace VirtoCommerce.OrdersModule.Tests
         [Fact]
         public void CalculateTotals_ClearAllItems_TotalsMustBeZero()
         {
-            var item1 = new LineItem { Price = 10.99m, DiscountAmount = 1.33m, TaxPercentRate = 0.12m, Fee = 0.33m, Quantity = 2 };
-            var item2 = new LineItem { Price = 55.22m, DiscountAmount = 5.89m, TaxPercentRate = 0.12m, Fee = 0.12m, Quantity = 5 };
-            var item3 = new LineItem { Price = 88.45m, DiscountAmount = 10.78m, TaxPercentRate = 0.12m, Fee = 0.08m, Quantity = 12 };
-            var payment = new PaymentIn { Price = 44.52m, DiscountAmount = 10, TaxPercentRate = 0.12m };
-            var shipment = new Shipment { Price = 22.0m, DiscountAmount = 5m, TaxPercentRate = 0.12m };
+            var item1 = new LineItem { Price = 10.99m, DiscountAmount = 1.33m, TaxPercentRate = 0.12m, Fee = 0.33m, Quantity = 2, Currency = "USD" };
+            var item2 = new LineItem { Price = 55.22m, DiscountAmount = 5.89m, TaxPercentRate = 0.12m, Fee = 0.12m, Quantity = 5, Currency = "USD" };
+            var item3 = new LineItem { Price = 88.45m, DiscountAmount = 10.78m, TaxPercentRate = 0.12m, Fee = 0.08m, Quantity = 12, Currency = "USD" };
+            var payment = new PaymentIn { Price = 44.52m, DiscountAmount = 10, TaxPercentRate = 0.12m, Currency = "USD" };
+            var shipment = new Shipment { Price = 22.0m, DiscountAmount = 5m, TaxPercentRate = 0.12m, Currency = "USD" };
 
             var order = new CustomerOrder
             {
                 TaxPercentRate = 0.12m,
                 Items = new List<LineItem> { item1, item2, item3 },
                 InPayments = new List<PaymentIn> { payment },
-                Shipments = new List<Shipment> { shipment }
+                Shipments = new List<Shipment> { shipment },
+                Currency = "USD",
             };
 
             var currency = new Currency
             {
-                Code = order.Currency,
+                Code = "USD",
                 RoundingPolicy = new DefaultMoneyRoundingPolicy()
             };
 
@@ -122,11 +125,11 @@ namespace VirtoCommerce.OrdersModule.Tests
         [Fact]
         public void CalculateTotals_ShouldBe_RightTotals()
         {
-            var item1 = new LineItem { Price = 10.99m, DiscountAmount = 1.33m, TaxPercentRate = 0.12m, Fee = 0.33m, Quantity = 2 };
-            var item2 = new LineItem { Price = 55.22m, DiscountAmount = 5.89m, TaxPercentRate = 0.12m, Fee = 0.12m, Quantity = 5 };
-            var item3 = new LineItem { Price = 88.45m, DiscountAmount = 10.78m, TaxPercentRate = 0.12m, Fee = 0.08m, Quantity = 12 };
-            var payment = new PaymentIn { Price = 44.52m, DiscountAmount = 10, TaxPercentRate = 0.12m };
-            var shipment = new Shipment { Price = 22.0m, DiscountAmount = 5m, TaxPercentRate = 0.12m, Fee = 20m };
+            var item1 = new LineItem { Price = 10.99m, DiscountAmount = 1.33m, TaxPercentRate = 0.12m, Fee = 0.33m, Quantity = 2, Currency = "USD" };
+            var item2 = new LineItem { Price = 55.22m, DiscountAmount = 5.89m, TaxPercentRate = 0.12m, Fee = 0.12m, Quantity = 5, Currency = "USD" };
+            var item3 = new LineItem { Price = 88.45m, DiscountAmount = 10.78m, TaxPercentRate = 0.12m, Fee = 0.08m, Quantity = 12, Currency = "USD" };
+            var payment = new PaymentIn { Price = 44.52m, DiscountAmount = 10, TaxPercentRate = 0.12m, Currency = "USD" };
+            var shipment = new Shipment { Price = 22.0m, DiscountAmount = 5m, TaxPercentRate = 0.12m, Fee = 20m, Currency = "USD" };
 
             var order = new CustomerOrder
             {
@@ -134,11 +137,13 @@ namespace VirtoCommerce.OrdersModule.Tests
                 Fee = 13.11m,
                 Items = new List<LineItem> { item1, item2, item3 },
                 InPayments = new List<PaymentIn> { payment },
-                Shipments = new List<Shipment> { shipment }
+                Shipments = new List<Shipment> { shipment },
+                Currency = "USD",
             };
 
             var currency = new Currency
             {
+                Code = "USD",
                 RoundingPolicy = new DefaultMoneyRoundingPolicy()
             };
 


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core order total calculation and depends on per-line-item currency; wrong or missing currency codes could skew totals or fail currency lookup at runtime.
> 
> **Overview**
> Adds **per-currency order totals** for orders whose line items, shipments, or payments use more than one currency.
> 
> **Backend:** Introduces `OrderTotal` and `CustomerOrder.OrderTotals`, plus `WithOrderTotals` on `CustomerOrderResponseGroup` (included in `Full`). `DefaultCustomerOrderTotalsCalculator` now groups child operations by currency, applies rounding per currency, and fills `OrderTotals` with subtotal, tax, discount, and total per code while still updating the main order’s scalar fields for the order’s primary currency.
> 
> **Admin UI:** The customer order line-items blade is wider, shows a **Currency** column on each row, and renders extra summary strips for non-primary currencies from `orderTotals`. Locales gain a `currency` label for that column.
> 
> Tests set explicit `Currency` on fixtures to match the calculator’s per-line-item currency lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4daf389fc0e22e48d1d98d22c9ce61898265a15e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->