### PR TITLE
VCST-5427: Register order validators as singletons

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,20 @@ namespace VirtoCommerce.OrdersModule.Web.Extensions
 {
     public static class ServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers the order FluentValidation validators as singletons — their rule trees are
+        /// stateless after construction, so a single reused instance avoids rebuilding the rule tree
+        /// on every resolve.
+        /// </summary>
+        /// <remarks>
+        /// CustomerOrderValidator is a singleton and captures its child validators
+        /// (IValidator&lt;LineItem&gt;, IValidator&lt;Shipment&gt;, IValidator&lt;IOperation&gt;) at
+        /// construction via SetValidator. Any child validator a downstream module registers is therefore
+        /// captured for the application lifetime: register such child validators as singletons and keep
+        /// them free of scoped/transient dependencies (for example a scoped DbContext), otherwise the
+        /// singleton captures them (a captive dependency). Enabling ValidateScopes / ValidateOnBuild on
+        /// the host surfaces such misconfigurations at startup instead of failing intermittently at runtime.
+        /// </remarks>
         public static void AddValidators(this IServiceCollection serviceCollection)
         {
             // Register operation-level validators

--- a/src/VirtoCommerce.OrdersModule.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Extensions/ServiceCollectionExtensions.cs
@@ -11,12 +11,12 @@ namespace VirtoCommerce.OrdersModule.Web.Extensions
         public static void AddValidators(this IServiceCollection serviceCollection)
         {
             // Register operation-level validators
-            serviceCollection.AddTransient<IValidator<IOperation>, OrderDocumentCountValidator>();
+            serviceCollection.AddSingleton<IValidator<IOperation>, OrderDocumentCountValidator>();
             
             // Register entity-specific validators
-            serviceCollection.AddTransient<IValidator<CustomerOrder>, CustomerOrderValidator>();
-            serviceCollection.AddTransient<IValidator<PaymentIn>, PaymentInValidator>();
-            serviceCollection.AddTransient<IValidator<OrderPaymentInfo>, PaymentRequestValidator>();
+            serviceCollection.AddSingleton<IValidator<CustomerOrder>, CustomerOrderValidator>();
+            serviceCollection.AddSingleton<IValidator<PaymentIn>, PaymentInValidator>();
+            serviceCollection.AddSingleton<IValidator<OrderPaymentInfo>, PaymentRequestValidator>();
         }
     }
 }


### PR DESCRIPTION
## Summary

FluentValidation `AbstractValidator<T>` subclasses are stateless after construction — the rule tree is immutable and per-call state lives in the `ValidationContext`. Registered as transient, they rebuild the full rule tree (re-running `RuleFor`/`RuleForEach`/`SetValidator` expression-tree compilation) on every DI resolve. These validators are resolved on the order-creation path (per order-aggregate build, e.g. `createOrderFromCart`), so the construction cost repeats per request.

## Changes

`ServiceCollectionExtensions.AddValidators`: `AddTransient` → `AddSingleton` for the four order validators:

- `IValidator<CustomerOrder>` → `CustomerOrderValidator`
- `IValidator<PaymentIn>` → `PaymentInValidator`
- `IValidator<OrderPaymentInfo>` → `PaymentRequestValidator`
- `IValidator<IOperation>` → `OrderDocumentCountValidator`

Converted as a set: `CustomerOrderValidator` injects `IValidator<PaymentIn>` and `IEnumerable<IValidator<IOperation>>` (two of the others) and captures them via `SetValidator` at construction, so promoting only the parent would capture transient children — all four go singleton together. The remaining constructor dependency is `ISettingsManager` (singleton), so there is no captive-dependency hazard. The open `IValidator<LineItem>` / `IValidator<Shipment>` extension points have no stock registrations; consumers that add child validators should register them as singletons to match.

## Downstream extensibility

Making `CustomerOrderValidator` a singleton tightens the contract for consumers that plug child validators into its `IValidator<LineItem>` / `IValidator<Shipment>` / `IValidator<IOperation>` extension points: because the parent captures them via `SetValidator` at construction, a downstream child validator is captured for the application lifetime. Such child validators should be registered as singletons and kept free of scoped/transient dependencies (e.g. a scoped `DbContext`), otherwise the singleton captures them (a captive dependency). A `<remarks>` on `AddValidators` documents this. Note that a downstream module that *overrides the top-level* `IValidator<CustomerOrder>` as transient is unaffected — a transient parent captures nothing long-term; only child-validator registrations interact with the singleton.

Enabling `ValidateScopes` / `ValidateOnBuild` on the host catches the dangerous (scoped-captured-by-singleton) subset at startup rather than intermittently at runtime.

## Tests

Lifetime-only DI registration change — no validator rules, messages, or behavior changed.

Sibling of VirtoCommerce/vc-module-catalog#897 (product / property / has-properties validators) and VirtoCommerce/vc-module-customer#306 (member validator).

Ref: VCST-5427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5427
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1013.0-pr-501-98fd.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DI lifetime-only change with no validation rule changes; documented caveat for modules that register scoped child validators.
> 
> **Overview**
> Registers the four order FluentValidation validators (`CustomerOrder`, `PaymentIn`, `OrderPaymentInfo`, `IOperation`) as **singletons** instead of **transient**, so the immutable rule trees are built once per app rather than on every resolve on hot paths like order creation from cart.
> 
> Adds XML docs on `AddValidators` explaining that `CustomerOrderValidator` captures child validators at construction and that downstream `LineItem` / `Shipment` / `IOperation` plug-ins should be singletons without scoped dependencies to avoid captive dependencies; recommends `ValidateScopes` / `ValidateOnBuild` on the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fd16884aa5785ccd45c699cc8b16a3701686a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->