### PR TITLE
VCST-5431: make order ConfigurationItem SectionName migration idempotent

### DIFF
--- a/src/VirtoCommerce.OrdersModule.Data.MySql/Migrations/20260604145421_AddConfigurationItemSectionName.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.MySql/Migrations/20260604145421_AddConfigurationItemSectionName.cs
@@ -10,21 +10,33 @@ namespace VirtoCommerce.OrdersModule.Data.MySql.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "SectionName",
-                table: "OrderConfigurationItem",
-                type: "varchar(256)",
-                maxLength: 256,
-                nullable: true)
-                .Annotation("MySql:CharSet", "utf8mb4");
+            migrationBuilder.Sql(
+                """
+                SET @columnExists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+                    WHERE TABLE_NAME = 'OrderConfigurationItem' AND COLUMN_NAME = 'SectionName' AND TABLE_SCHEMA = DATABASE());
+                SET @sql = IF(@columnExists = 0,
+                    'ALTER TABLE `OrderConfigurationItem` ADD COLUMN `SectionName` varchar(256) CHARACTER SET utf8mb4 NULL',
+                    'SELECT 1');
+                PREPARE stmt FROM @sql;
+                EXECUTE stmt;
+                DEALLOCATE PREPARE stmt;
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "SectionName",
-                table: "OrderConfigurationItem");
+            migrationBuilder.Sql(
+                """
+                SET @columnExists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+                    WHERE TABLE_NAME = 'OrderConfigurationItem' AND COLUMN_NAME = 'SectionName' AND TABLE_SCHEMA = DATABASE());
+                SET @sql = IF(@columnExists > 0,
+                    'ALTER TABLE `OrderConfigurationItem` DROP COLUMN `SectionName`',
+                    'SELECT 1');
+                PREPARE stmt FROM @sql;
+                EXECUTE stmt;
+                DEALLOCATE PREPARE stmt;
+                """);
         }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20260604145406_AddConfigurationItemSectionName.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/Migrations/20260604145406_AddConfigurationItemSectionName.cs
@@ -10,20 +10,19 @@ namespace VirtoCommerce.OrdersModule.Data.PostgreSql.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "SectionName",
-                table: "OrderConfigurationItem",
-                type: "character varying(256)",
-                maxLength: 256,
-                nullable: true);
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE "OrderConfigurationItem" ADD COLUMN IF NOT EXISTS "SectionName" character varying(256) NULL;
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "SectionName",
-                table: "OrderConfigurationItem");
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE "OrderConfigurationItem" DROP COLUMN IF EXISTS "SectionName";
+                """);
         }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/20260604145413_AddConfigurationItemSectionName.cs
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/Migrations/20260604145413_AddConfigurationItemSectionName.cs
@@ -10,20 +10,21 @@ namespace VirtoCommerce.OrdersModule.Data.SqlServer.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "SectionName",
-                table: "OrderConfigurationItem",
-                type: "nvarchar(256)",
-                maxLength: 256,
-                nullable: true);
+            migrationBuilder.Sql(
+                """
+                IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('OrderConfigurationItem') AND name = 'SectionName')
+                    ALTER TABLE [OrderConfigurationItem] ADD [SectionName] nvarchar(256) NULL
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "SectionName",
-                table: "OrderConfigurationItem");
+            migrationBuilder.Sql(
+                """
+                IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('OrderConfigurationItem') AND name = 'SectionName')
+                    ALTER TABLE [OrderConfigurationItem] DROP COLUMN [SectionName]
+                """);
         }
     }
 }


### PR DESCRIPTION
## What
Makes the `AddConfigurationItemSectionName` migration idempotent across all three DB providers (PostgreSQL, SQL Server, MySQL): `Up` adds the `SectionName` column to `OrderConfigurationItem` only if it does not already exist, and `Down` drops it only if present.

## Why
Consumer modules that added the same `SectionName` column to `OrderConfigurationItem` through their own earlier migration cause the plain `AddColumn` to fail ("column already exists") when this base migration runs on those already-migrated databases. Guarding the add/drop lets the base migration run cleanly regardless of whether the column is already there.

## How
Raw-SQL guards mirroring the existing `vc-module-import` `AddCursor` precedent:
- PostgreSQL — `ADD COLUMN IF NOT EXISTS` / `DROP COLUMN IF EXISTS`
- SQL Server — `sys.columns` existence guard around `ALTER TABLE ... ADD` / `DROP COLUMN`
- MySQL — `INFORMATION_SCHEMA.COLUMNS` count + prepared statement

Column shape is unchanged (`character varying(256)` / `nvarchar(256)` / `varchar(256)` utf8mb4, nullable). Only the `Up`/`Down` bodies change.

## Verification
- `dotnet build VirtoCommerce.OrdersModule.sln` — succeeds (0 errors).
- `dotnet ef migrations has-pending-model-changes` — "No changes" on all three provider contexts.
- No `*.Designer.cs` / `*ModelSnapshot.cs` changes — the column shape (and thus the model snapshot) is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only migration guards with no application logic changes; low risk aside from ensuring raw SQL matches existing column definitions on partially migrated databases.
> 
> **Overview**
> **`AddConfigurationItemSectionName`** no longer uses EF `AddColumn` / `DropColumn` for `OrderConfigurationItem.SectionName`. **Up** and **Down** now run provider-specific raw SQL that only adds or drops the column when it is missing or present.
> 
> PostgreSQL uses `ADD COLUMN IF NOT EXISTS` / `DROP COLUMN IF EXISTS`. SQL Server checks `sys.columns` before `ALTER TABLE`. MySQL uses `INFORMATION_SCHEMA.COLUMNS` and a prepared statement. Column type and nullability are unchanged; only migration execution is guarded so databases that already have `SectionName` from consumer migrations do not fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8144d71ee645c338f212e9a741ce35d64067bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5431
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1012.0-pr-502-af81.zip