### PR TITLE
VCST-5490: use BackgroundJobs

### DIFF
--- a/samples/VirtoCommerce.OrdersModule2.Web/VirtoCommerce.OrdersModule2.Web.csproj
+++ b/samples/VirtoCommerce.OrdersModule2.Web/VirtoCommerce.OrdersModule2.Web.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.OrdersModule.Core\VirtoCommerce.OrdersModule.Core.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
+++ b/src/VirtoCommerce.OrdersModule.Core/VirtoCommerce.OrdersModule.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />

--- a/src/VirtoCommerce.OrdersModule.Data.MySql/VirtoCommerce.OrdersModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data.MySql/VirtoCommerce.OrdersModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Data\VirtoCommerce.OrdersModule.Data.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Data.PostgreSql/VirtoCommerce.OrdersModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data.PostgreSql/VirtoCommerce.OrdersModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Data\VirtoCommerce.OrdersModule.Data.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Data.SqlServer/VirtoCommerce.OrdersModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data.SqlServer/VirtoCommerce.OrdersModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Data\VirtoCommerce.OrdersModule.Data.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.Extensions.Logging;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
@@ -11,8 +10,10 @@ using VirtoCommerce.InventoryModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core;
 using VirtoCommerce.OrdersModule.Core.Events;
 using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Services;
 
@@ -69,8 +70,13 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                 //Do not process prototypes
                 if (!customerOrder.IsPrototype)
                 {
+                    var payload = AbstractTypeFactory<AdjustInventoryJobPayload>.TryCreateInstance();
+                    payload.ChangedEntry = changedEntry;
+
                     //Background task is used here to  prevent concurrent update conflicts that can be occur during applying of adjustments for same inventory object
-                    BackgroundJob.Enqueue(() => ProcessInventoryChanges(changedEntry));
+                    //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once
+                    //from the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                    await BackgroundJob.Enqueue<AdjustInventoryJobHandler>(payload);
                 }
             }
         }

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/AdjustInventoryOrderChangedEventHandler.cs
@@ -70,8 +70,9 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                 //Do not process prototypes
                 if (!customerOrder.IsPrototype)
                 {
-                    var payload = AbstractTypeFactory<AdjustInventoryJobPayload>.TryCreateInstance();
-                    payload.ChangedEntry = changedEntry;
+                    //Only the fields ProcessInventoryChanges reads are carried over: the payload is serialized without
+                    //type information, so the order graph itself cannot be read back on the worker.
+                    var payload = AdjustInventoryJobPayload.FromChangedEntry(changedEntry);
 
                     //Background task is used here to  prevent concurrent update conflicts that can be occur during applying of adjustments for same inventory object
                     //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/CancelPaymentOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/CancelPaymentOrderChangedEventHandler.cs
@@ -2,14 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.OrdersModule.Core.Events;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Services;
+using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Model.Requests;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 
 namespace VirtoCommerce.OrdersModule.Data.Handlers
 {
@@ -28,7 +29,12 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
 
             if (jobArguments.Any())
             {
-                BackgroundJob.Enqueue(() => TryToCancelOrderPaymentsAsync(jobArguments));
+                var payload = AbstractTypeFactory<CancelPaymentJobPayload>.TryCreateInstance();
+                payload.JobArguments = jobArguments;
+
+                //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once
+                //from the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                return BackgroundJob.Enqueue<CancelPaymentJobHandler>(payload);
             }
             return Task.CompletedTask;
         }

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/LogChangesOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/LogChangesOrderChangedEventHandler.cs
@@ -4,16 +4,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoCompare;
-using Hangfire;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core;
 using VirtoCommerce.OrdersModule.Core.Events;
 using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
 using Address = VirtoCommerce.OrdersModule.Core.Model.Address;
 
@@ -43,7 +44,12 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
 
                 if (!operationLogs.IsNullOrEmpty())
                 {
-                    BackgroundJob.Enqueue(() => TryToLogChangesBackgroundJob(operationLogs.ToArray()));
+                    var payload = AbstractTypeFactory<LogOrderChangesJobPayload>.TryCreateInstance();
+                    payload.OperationLogs = operationLogs.ToArray();
+
+                    //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once
+                    //from the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                    await BackgroundJob.Enqueue<LogOrderChangesJobHandler>(payload);
                 }
             }
         }

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/RefundChangedOrderChangedEventHandler.cs
@@ -3,14 +3,15 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.OrdersModule.Core.Events;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Services;
+using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Model.Requests;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.StoreModule.Core.Services;
 
@@ -38,7 +39,12 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
 
             if (jobArguments.Length > 0)
             {
-                BackgroundJob.Enqueue(() => ProcessRefundChangesAsync(jobArguments));
+                var payload = AbstractTypeFactory<RefundChangedJobPayload>.TryCreateInstance();
+                payload.JobArguments = jobArguments;
+
+                //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once
+                //from the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                return BackgroundJob.Enqueue<RefundChangedJobHandler>(payload);
             }
 
             return Task.CompletedTask;

--- a/src/VirtoCommerce.OrdersModule.Data/Handlers/SendNotificationsOrderChangedEventHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Handlers/SendNotificationsOrderChangedEventHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
@@ -14,9 +13,11 @@ using VirtoCommerce.OrdersModule.Core.Events;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Notifications;
 using VirtoCommerce.OrdersModule.Core.Services;
+using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Model;
@@ -59,7 +60,12 @@ namespace VirtoCommerce.OrdersModule.Data.Handlers
                 var jobArguments = message.ChangedEntries.SelectMany(GetJobArgumentsForChangedEntry).ToArray();
                 if (jobArguments.Any())
                 {
-                    BackgroundJob.Enqueue(() => TryToSendOrderNotificationsAsync(jobArguments));
+                    var payload = AbstractTypeFactory<SendOrderNotificationsJobPayload>.TryCreateInstance();
+                    payload.JobArguments = jobArguments;
+
+                    //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once
+                    //from the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                    await BackgroundJob.Enqueue<SendOrderNotificationsJobHandler>(payload);
                 }
             }
         }

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.OrdersModule.Data.Jobs
     {
         public virtual Task Execute(AdjustInventoryJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
-            return eventHandler.ProcessInventoryChanges(payload.ChangedEntry);
+            return eventHandler.ProcessInventoryChanges(payload.ToChangedEntry());
         }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Adjusts reserved stock for a changed order, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="AdjustInventoryOrderChangedEventHandler"/>, which still owns the logic and stays callable by
+    /// background jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class AdjustInventoryJobHandler(AdjustInventoryOrderChangedEventHandler eventHandler) : IBackgroundJobHandler<AdjustInventoryJobPayload>
+    {
+        public virtual Task Execute(AdjustInventoryJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.ProcessInventoryChanges(payload.ChangedEntry);
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobLineItem.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobLineItem.cs
@@ -1,0 +1,42 @@
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// The part of an ordered line item that the inventory adjustment job needs.
+    /// </summary>
+    public class AdjustInventoryJobLineItem
+    {
+        /// <summary>Line item id. The reservation is keyed by it, and the old and new items are matched by it.</summary>
+        public string Id { get; set; }
+
+        /// <summary>Product the line item was ordered for.</summary>
+        public string ProductId { get; set; }
+
+        /// <summary>Ordered quantity.</summary>
+        public int Quantity { get; set; }
+
+        public static AdjustInventoryJobLineItem FromLineItem(LineItem lineItem)
+        {
+            var result = AbstractTypeFactory<AdjustInventoryJobLineItem>.TryCreateInstance();
+
+            result.Id = lineItem.Id;
+            result.ProductId = lineItem.ProductId;
+            result.Quantity = lineItem.Quantity;
+
+            return result;
+        }
+
+        public virtual LineItem ToLineItem()
+        {
+            var result = AbstractTypeFactory<LineItem>.TryCreateInstance();
+
+            result.Id = Id;
+            result.ProductId = ProductId;
+            result.Quantity = Quantity;
+
+            return result;
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobPayload.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobPayload.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
 using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
 
 namespace VirtoCommerce.OrdersModule.Data.Jobs
@@ -6,9 +9,79 @@ namespace VirtoCommerce.OrdersModule.Data.Jobs
     /// <summary>
     /// Payload of the background job that adjusts reserved stock for a changed order.
     /// </summary>
+    /// <remarks>
+    /// Deliberately a projection of the order rather than the order itself: a payload is serialized without type
+    /// information, so a whole <see cref="CustomerOrder"/> cannot be read back on the worker - it reaches
+    /// <see cref="PaymentIn.PaymentMethod"/>, <see cref="Shipment.ShippingMethod"/> or
+    /// <see cref="OrderOperation.ChildrenOperations"/> and fails on an abstract or interface type. This carries the fields
+    /// <see cref="Handlers.AdjustInventoryOrderChangedEventHandler.ProcessInventoryChanges"/> actually reads, and
+    /// nothing else - which also keeps the job store small, since the order graph would otherwise be stored twice.
+    /// </remarks>
     public class AdjustInventoryJobPayload
     {
-        /// <summary>The changed order entry whose reservations must be applied.</summary>
-        public GenericChangedEntry<CustomerOrder> ChangedEntry { get; set; }
+        /// <summary>Id of the changed order.</summary>
+        public string OrderId { get; set; }
+
+        /// <summary>Store the changed order belongs to, used to resolve the fulfillment centers.</summary>
+        public string StoreId { get; set; }
+
+        /// <summary>How the order itself changed.</summary>
+        public EntryState EntryState { get; set; }
+
+        /// <summary>Order status after the change.</summary>
+        public string NewStatus { get; set; }
+
+        /// <summary>Order status before the change.</summary>
+        public string OldStatus { get; set; }
+
+        /// <summary>Ordered line items after the change.</summary>
+        public IList<AdjustInventoryJobLineItem> NewItems { get; set; } = [];
+
+        /// <summary>Ordered line items before the change.</summary>
+        public IList<AdjustInventoryJobLineItem> OldItems { get; set; } = [];
+
+        public static AdjustInventoryJobPayload FromChangedEntry(GenericChangedEntry<CustomerOrder> changedEntry)
+        {
+            var result = AbstractTypeFactory<AdjustInventoryJobPayload>.TryCreateInstance();
+
+            result.OrderId = changedEntry.NewEntry.Id;
+            result.StoreId = changedEntry.NewEntry.StoreId;
+            result.EntryState = changedEntry.EntryState;
+            result.NewStatus = changedEntry.NewEntry.Status;
+            result.OldStatus = changedEntry.OldEntry?.Status;
+            result.NewItems = ToJobLineItems(changedEntry.NewEntry.Items);
+            result.OldItems = ToJobLineItems(changedEntry.OldEntry?.Items);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Restores the entry the handler works with. Everything the projection does not carry stays unset, so the
+        /// orders are only ever valid as input for the inventory adjustment.
+        /// </summary>
+        public virtual GenericChangedEntry<CustomerOrder> ToChangedEntry()
+        {
+            return new GenericChangedEntry<CustomerOrder>(
+                ToOrder(NewStatus, NewItems),
+                ToOrder(OldStatus, OldItems),
+                EntryState);
+        }
+
+        protected virtual CustomerOrder ToOrder(string status, IList<AdjustInventoryJobLineItem> items)
+        {
+            var order = AbstractTypeFactory<CustomerOrder>.TryCreateInstance();
+
+            order.Id = OrderId;
+            order.StoreId = StoreId;
+            order.Status = status;
+            order.Items = items?.Select(x => x.ToLineItem()).ToList() ?? [];
+
+            return order;
+        }
+
+        protected static IList<AdjustInventoryJobLineItem> ToJobLineItems(ICollection<LineItem> items)
+        {
+            return items?.Select(AdjustInventoryJobLineItem.FromLineItem).ToList() ?? [];
+        }
     }
 }

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobPayload.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/AdjustInventoryJobPayload.cs
@@ -1,0 +1,14 @@
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.Platform.Core.Events;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that adjusts reserved stock for a changed order.
+    /// </summary>
+    public class AdjustInventoryJobPayload
+    {
+        /// <summary>The changed order entry whose reservations must be applied.</summary>
+        public GenericChangedEntry<CustomerOrder> ChangedEntry { get; set; }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/CancelPaymentJobHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/CancelPaymentJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Voids or refunds the payments a changed order asked to cancel, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="CancelPaymentOrderChangedEventHandler"/>, which still owns the logic and stays callable by
+    /// background jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class CancelPaymentJobHandler(CancelPaymentOrderChangedEventHandler eventHandler) : IBackgroundJobHandler<CancelPaymentJobPayload>
+    {
+        public virtual Task Execute(CancelPaymentJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.TryToCancelOrderPaymentsAsync(payload.JobArguments);
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/CancelPaymentJobPayload.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/CancelPaymentJobPayload.cs
@@ -1,0 +1,13 @@
+using VirtoCommerce.OrdersModule.Data.Handlers;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that voids or refunds the payments a changed order asked to cancel.
+    /// </summary>
+    public class CancelPaymentJobPayload
+    {
+        /// <summary>The payments to cancel, one argument per order payment.</summary>
+        public PaymentToCancelJobArgument[] JobArguments { get; set; }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/LogOrderChangesJobHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/LogOrderChangesJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Persists the change-log entries collected for a changed order, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="LogChangesOrderChangedEventHandler"/>, which still owns the logic and stays callable by
+    /// background jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class LogOrderChangesJobHandler(LogChangesOrderChangedEventHandler eventHandler) : IBackgroundJobHandler<LogOrderChangesJobPayload>
+    {
+        public virtual Task Execute(LogOrderChangesJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.TryToLogChangesBackgroundJob(payload.OperationLogs);
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/LogOrderChangesJobPayload.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/LogOrderChangesJobPayload.cs
@@ -1,0 +1,13 @@
+using VirtoCommerce.Platform.Core.ChangeLog;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that persists the change-log entries collected for a changed order.
+    /// </summary>
+    public class LogOrderChangesJobPayload
+    {
+        /// <summary>The change-log entries to persist.</summary>
+        public OperationLog[] OperationLogs { get; set; }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/RefundChangedJobHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/RefundChangedJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Processes the refunds requested on a changed order, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="RefundChangedOrderChangedEventHandler"/>, which still owns the logic and stays callable by
+    /// background jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class RefundChangedJobHandler(RefundChangedOrderChangedEventHandler eventHandler) : IBackgroundJobHandler<RefundChangedJobPayload>
+    {
+        public virtual Task Execute(RefundChangedJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.ProcessRefundChangesAsync(payload.JobArguments);
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/RefundChangedJobPayload.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/RefundChangedJobPayload.cs
@@ -1,0 +1,13 @@
+using VirtoCommerce.OrdersModule.Data.Handlers;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that processes the refunds requested on a changed order.
+    /// </summary>
+    public class RefundChangedJobPayload
+    {
+        /// <summary>The refunds to process, one argument per payment refund.</summary>
+        public RefundChangedJobArgument[] JobArguments { get; set; }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/SendOrderNotificationsJobHandler.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/SendOrderNotificationsJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Sends the notifications a changed order triggered, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="SendNotificationsOrderChangedEventHandler"/>, which still owns the logic and stays callable by
+    /// background jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class SendOrderNotificationsJobHandler(SendNotificationsOrderChangedEventHandler eventHandler) : IBackgroundJobHandler<SendOrderNotificationsJobPayload>
+    {
+        public virtual Task Execute(SendOrderNotificationsJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.TryToSendOrderNotificationsAsync(payload.JobArguments);
+        }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/Jobs/SendOrderNotificationsJobPayload.cs
+++ b/src/VirtoCommerce.OrdersModule.Data/Jobs/SendOrderNotificationsJobPayload.cs
@@ -1,0 +1,13 @@
+using VirtoCommerce.OrdersModule.Data.Handlers;
+
+namespace VirtoCommerce.OrdersModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that sends the notifications a changed order triggered.
+    /// </summary>
+    public class SendOrderNotificationsJobPayload
+    {
+        /// <summary>The notifications to send, one argument per notification.</summary>
+        public OrderNotificationJobArgument[] JobArguments { get; set; }
+    }
+}

--- a/src/VirtoCommerce.OrdersModule.Data/VirtoCommerce.OrdersModule.Data.csproj
+++ b/src/VirtoCommerce.OrdersModule.Data/VirtoCommerce.OrdersModule.Data.csproj
@@ -19,9 +19,8 @@
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1052.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OrdersModule.Core\VirtoCommerce.OrdersModule.Core.csproj" />

--- a/src/VirtoCommerce.OrdersModule.Web/Module.cs
+++ b/src/VirtoCommerce.OrdersModule.Web/Module.cs
@@ -24,6 +24,7 @@ using VirtoCommerce.OrdersModule.Core.Services;
 using VirtoCommerce.OrdersModule.Data.Authorization;
 using VirtoCommerce.OrdersModule.Data.ExportImport;
 using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.OrdersModule.Data.MySql;
 using VirtoCommerce.OrdersModule.Data.PostgreSql;
 using VirtoCommerce.OrdersModule.Data.Repositories;
@@ -37,6 +38,7 @@ using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -102,6 +104,15 @@ namespace VirtoCommerce.OrdersModule.Web
             serviceCollection.AddTransient<IndexCustomerOrderChangedEventHandler>();
             serviceCollection.AddTransient<IPaymentFlowService, PaymentFlowService>();
             serviceCollection.AddTransient<SendNotificationsOrderChangedEventHandler>();
+
+            // None of these is triggerable by name: each acts on a caller-supplied payload with real side effects -
+            // stock reservations, payment voids and refunds, customer emails, and audit-log rows whose Id would take
+            // ChangeLogService.SaveChangesAsync's Patch branch and overwrite an existing entry.
+            serviceCollection.AddBackgroundJob<AdjustInventoryJobHandler, AdjustInventoryJobPayload>(triggerable: false);
+            serviceCollection.AddBackgroundJob<CancelPaymentJobHandler, CancelPaymentJobPayload>(triggerable: false);
+            serviceCollection.AddBackgroundJob<RefundChangedJobHandler, RefundChangedJobPayload>(triggerable: false);
+            serviceCollection.AddBackgroundJob<LogOrderChangesJobHandler, LogOrderChangesJobPayload>(triggerable: false);
+            serviceCollection.AddBackgroundJob<SendOrderNotificationsJobHandler, SendOrderNotificationsJobPayload>(triggerable: false);
             serviceCollection.AddTransient<PolymorphicOperationJsonConverter>();
             serviceCollection.AddTransient<IAuthorizationHandler, OrderAuthorizationHandler>();
             serviceCollection.AddTransient<IPaymentRequestConverter, PaymentRequestDefaultConverter>();

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -4,9 +4,10 @@
   <version>3.1014.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1007.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />

--- a/src/VirtoCommerce.OrdersModule.Web/module.manifest
+++ b/src/VirtoCommerce.OrdersModule.Web/module.manifest
@@ -7,7 +7,6 @@
   <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
-    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1007.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />

--- a/tests/VirtoCommerce.OrdersModule.Tests/BackgroundJobEnqueueTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/BackgroundJobEnqueueTests.cs
@@ -1,9 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Newtonsoft.Json;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.InventoryModule.Core.Model;
+using VirtoCommerce.InventoryModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core;
 using VirtoCommerce.OrdersModule.Core.Events;
 using VirtoCommerce.OrdersModule.Core.Model;
@@ -13,8 +20,11 @@ using VirtoCommerce.OrdersModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
 using Xunit;
 
 namespace VirtoCommerce.OrdersModule.Tests
@@ -25,6 +35,15 @@ namespace VirtoCommerce.OrdersModule.Tests
     [Collection(nameof(BackgroundJobEnqueueTests))]
     public class BackgroundJobEnqueueTests
     {
+        // Mirrors JobJsonSettings.Default of the BackgroundJobs module: no TypeNameHandling, which is precisely what
+        // every payload has to survive. The order module depends on the Platform.Core.Jobs abstractions only, so the
+        // settings are restated here rather than referenced.
+        private static readonly JsonSerializerSettings JobSerializerSettings = new()
+        {
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            NullValueHandling = NullValueHandling.Include,
+        };
+
         [Fact]
         public async Task LogChanges_LoggingEnabled_EnqueuesTheCollectedLogs()
         {
@@ -110,6 +129,94 @@ namespace VirtoCommerce.OrdersModule.Tests
         }
 
         [Fact]
+        public void AdjustInventory_PayloadCarriesNothingPolymorphic_AndSurvivesJobSerialization()
+        {
+            //Arrange
+            // The engine serializes the payload with no TypeNameHandling, so anything polymorphic reachable from it
+            // (PaymentIn.PaymentMethod, Shipment.ShippingMethod, IOperation.ChildrenOperations) is written without a
+            // $type and cannot be read back on the worker. The payload must therefore carry a projection, not the order.
+            var payload = AdjustInventoryJobPayload.FromChangedEntry(CreateChangedEntry());
+
+            //Act
+            var json = JsonConvert.SerializeObject(payload, JobSerializerSettings);
+            var restored = JsonConvert.DeserializeObject<AdjustInventoryJobPayload>(json, JobSerializerSettings);
+
+            //Assert
+            var changedEntry = restored.ToChangedEntry();
+            Assert.Equal(EntryState.Modified, changedEntry.EntryState);
+            Assert.Equal("order1", changedEntry.NewEntry.Id);
+            Assert.Equal("store1", changedEntry.NewEntry.StoreId);
+            Assert.Equal(ModuleConstants.CustomerOrderStatus.Cancelled, changedEntry.NewEntry.Status);
+            Assert.Equal("New", changedEntry.OldEntry.Status);
+
+            var newItem = Assert.Single(changedEntry.NewEntry.Items);
+            Assert.Equal("item1", newItem.Id);
+            Assert.Equal("product1", newItem.ProductId);
+            Assert.Equal(3, newItem.Quantity);
+
+            var oldItem = Assert.Single(changedEntry.OldEntry.Items);
+            Assert.Equal("item1", oldItem.Id);
+            Assert.Equal("product1", oldItem.ProductId);
+            Assert.Equal(2, oldItem.Quantity);
+        }
+
+        [Fact]
+        public async Task AdjustInventory_ReleasesCancelledItems_AfterThePayloadRoundTrip()
+        {
+            //Arrange
+            // Proves the projection carries everything ProcessInventoryChanges reads: the payload goes through the
+            // real enqueue path and the engine's serialization before the job handler runs it.
+            using var capture = new EnqueueCapture();
+            var reservationServiceMock = new Mock<IInventoryReservationService>();
+            var eventHandler = CreateAdjustInventoryHandler(reservationServiceMock);
+
+            //Act
+            await eventHandler.Handle(new OrderChangedEvent([CreateChangedEntry()]));
+
+            var payload = Assert.IsType<AdjustInventoryJobPayload>(capture.Payload);
+            var json = JsonConvert.SerializeObject(payload, JobSerializerSettings);
+            var restored = JsonConvert.DeserializeObject<AdjustInventoryJobPayload>(json, JobSerializerSettings);
+
+            await new AdjustInventoryJobHandler(eventHandler).Execute(restored, context: null, TestContext.Current.CancellationToken);
+
+            //Assert
+            reservationServiceMock.Verify(x => x.ReleaseAsync(It.Is<InventoryReleaseRequest>(request =>
+                request.ParentId == "order1" &&
+                request.Items.Count == 1 &&
+                request.Items[0].ItemId == "item1" &&
+                request.Items[0].ProductId == "product1")), Times.Once);
+        }
+
+        [Fact]
+        public async Task AdjustInventory_ReservesOrderedItems_AfterThePayloadRoundTrip()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var reservationServiceMock = new Mock<IInventoryReservationService>();
+            var eventHandler = CreateAdjustInventoryHandler(reservationServiceMock);
+
+            var newOrder = CreateOrder("New", quantity: 3);
+
+            //Act
+            await eventHandler.Handle(new OrderChangedEvent([new GenericChangedEntry<CustomerOrder>(newOrder, EntryState.Added)]));
+
+            var payload = Assert.IsType<AdjustInventoryJobPayload>(capture.Payload);
+            var json = JsonConvert.SerializeObject(payload, JobSerializerSettings);
+            var restored = JsonConvert.DeserializeObject<AdjustInventoryJobPayload>(json, JobSerializerSettings);
+
+            await new AdjustInventoryJobHandler(eventHandler).Execute(restored, context: null, TestContext.Current.CancellationToken);
+
+            //Assert
+            reservationServiceMock.Verify(x => x.ReserveAsync(It.Is<InventoryReserveRequest>(request =>
+                request.ParentId == "order1" &&
+                request.FulfillmentCenterIds.Contains("fulfillmentCenter1") &&
+                request.Items.Count == 1 &&
+                request.Items[0].ItemId == "item1" &&
+                request.Items[0].ProductId == "product1" &&
+                request.Items[0].Quantity == 3)), Times.Once);
+        }
+
+        [Fact]
         public async Task CancelPaymentJobHandler_DelegatesToTheEventHandler()
         {
             //Arrange
@@ -134,12 +241,75 @@ namespace VirtoCommerce.OrdersModule.Tests
 
         private static ISettingsManager CreateSettingsManager(bool enabled)
         {
+            return CreateSettingsManager(ModuleConstants.Settings.General.LogOrderChanges.Name, enabled);
+        }
+
+        private static ISettingsManager CreateSettingsManager(string settingName, bool enabled)
+        {
             var settingsManager = new Mock<ISettingsManager>();
             settingsManager
-                .Setup(x => x.GetObjectSettingAsync(ModuleConstants.Settings.General.LogOrderChanges.Name, It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.GetObjectSettingAsync(settingName, It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new ObjectSettingEntry { Value = enabled });
 
             return settingsManager.Object;
+        }
+
+        private static AdjustInventoryOrderChangedEventHandler CreateAdjustInventoryHandler(Mock<IInventoryReservationService> reservationServiceMock)
+        {
+            var storeServiceMock = new Mock<IStoreService>();
+            storeServiceMock
+                .Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), false))
+                .ReturnsAsync([new Store { Id = "store1", MainFulfillmentCenterId = "fulfillmentCenter1" }]);
+
+            var itemServiceMock = new Mock<IItemService>();
+            itemServiceMock
+                .Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), false))
+                .ReturnsAsync([new CatalogProduct { Id = "product1", TrackInventory = true }]);
+
+            return new AdjustInventoryOrderChangedEventHandler(
+                storeServiceMock.Object,
+                CreateSettingsManager(ModuleConstants.Settings.General.OrderAdjustInventory.Name, enabled: true),
+                itemServiceMock.Object,
+                reservationServiceMock.Object,
+                Mock.Of<ILogger<AdjustInventoryOrderChangedEventHandler>>());
+        }
+
+        // A cancelled order: the quantity ordered before cancellation has to be released.
+        private static GenericChangedEntry<CustomerOrder> CreateChangedEntry()
+        {
+            return new GenericChangedEntry<CustomerOrder>(
+                CreateOrder(ModuleConstants.CustomerOrderStatus.Cancelled, quantity: 3),
+                CreateOrder("New", quantity: 2),
+                EntryState.Modified);
+        }
+
+        private static CustomerOrder CreateOrder(string status, int quantity)
+        {
+            var payment = new PaymentIn { Id = "payment1", PaymentMethod = new TestPaymentMethod() };
+
+            var order = new CustomerOrder
+            {
+                Id = "order1",
+                StoreId = "store1",
+                Status = status,
+                Items = [new LineItem { Id = "item1", ProductId = "product1", Quantity = quantity }],
+                InPayments = [payment],
+            };
+
+            // OperationEntity.ToModel fills this on every order read from the database. It is an IOperation
+            // collection, so it is the second member of the graph that no type-less serializer can read back.
+            order.ChildrenOperations = [payment];
+
+            return order;
+        }
+
+        // PaymentIn.PaymentMethod is an abstract type filled by CustomerOrderService.LoadOrderDependenciesAsync,
+        // which is what the payload used to drag into the job store.
+        private sealed class TestPaymentMethod() : PaymentMethod("test")
+        {
+            public override PaymentMethodType PaymentMethodType => PaymentMethodType.Unknown;
+
+            public override PaymentMethodGroupType PaymentMethodGroupType => PaymentMethodGroupType.Alternative;
         }
 
         // Captures what a handler enqueued through the static BackgroundJob facade. IBackgroundJob is registered
@@ -153,6 +323,7 @@ namespace VirtoCommerce.OrdersModule.Tests
             {
                 Setup<LogOrderChangesJobHandler>();
                 Setup<CancelPaymentJobHandler>();
+                Setup<AdjustInventoryJobHandler>();
 
                 var services = new ServiceCollection();
                 services.AddScoped(_ => BackgroundJobMock.Object);

--- a/tests/VirtoCommerce.OrdersModule.Tests/BackgroundJobEnqueueTests.cs
+++ b/tests/VirtoCommerce.OrdersModule.Tests/BackgroundJobEnqueueTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.OrdersModule.Core;
+using VirtoCommerce.OrdersModule.Core.Events;
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.OrdersModule.Core.Services;
+using VirtoCommerce.OrdersModule.Data.Handlers;
+using VirtoCommerce.OrdersModule.Data.Jobs;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.Platform.Core.Settings;
+using Xunit;
+
+namespace VirtoCommerce.OrdersModule.Tests
+{
+    // Any other test class that enqueues through the static BackgroundJob facade must join this collection:
+    // the facade has no reset API (Initialize rejects null), so Dispose leaves a DISPOSED provider behind in
+    // the static, and a class racing this one would see ObjectDisposedException from it.
+    [Collection(nameof(BackgroundJobEnqueueTests))]
+    public class BackgroundJobEnqueueTests
+    {
+        [Fact]
+        public async Task LogChanges_LoggingEnabled_EnqueuesTheCollectedLogs()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new LogChangesOrderChangedEventHandler(
+                Mock.Of<IChangeLogService>(),
+                Mock.Of<IMemberService>(),
+                CreateSettingsManager(enabled: true));
+
+            var order = new CustomerOrder { Id = "order1", Number = "ORD-1" };
+            var message = new OrderChangedEvent([new GenericChangedEntry<CustomerOrder>(order, order, EntryState.Added)]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            var payload = Assert.IsType<LogOrderChangesJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.NotEmpty(payload.OperationLogs);
+            Assert.All(payload.OperationLogs, x => Assert.Equal("order1", x.ObjectId));
+        }
+
+        [Fact]
+        public async Task LogChanges_LoggingDisabled_EnqueuesNothing()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new LogChangesOrderChangedEventHandler(
+                Mock.Of<IChangeLogService>(),
+                Mock.Of<IMemberService>(),
+                CreateSettingsManager(enabled: false));
+
+            var order = new CustomerOrder { Id = "order1", Number = "ORD-1" };
+
+            //Act
+            await handler.Handle(new OrderChangedEvent([new GenericChangedEntry<CustomerOrder>(order, order, EntryState.Added)]));
+
+            //Assert
+            Assert.Equal(0, capture.EnqueueCount);
+        }
+
+        [Fact]
+        public async Task CancelPayment_OrderCancelled_EnqueuesOneArgumentPerPayment()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new CancelPaymentOrderChangedEventHandler(Mock.Of<ICustomerOrderService>());
+
+            var oldOrder = new CustomerOrder { Id = "order1", IsCancelled = false, InPayments = [] };
+            var newOrder = new CustomerOrder
+            {
+                Id = "order1",
+                IsCancelled = true,
+                InPayments = [new PaymentIn { Id = "payment1" }],
+            };
+
+            //Act
+            await handler.Handle(new OrderChangedEvent([new GenericChangedEntry<CustomerOrder>(newOrder, oldOrder, EntryState.Modified)]));
+
+            //Assert
+            var payload = Assert.IsType<CancelPaymentJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            var argument = Assert.Single(payload.JobArguments);
+            Assert.Equal("order1", argument.CustomerOrderId);
+            Assert.Equal("payment1", argument.PaymentId);
+        }
+
+        [Fact]
+        public async Task CancelPayment_NothingToCancel_EnqueuesNothing()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new CancelPaymentOrderChangedEventHandler(Mock.Of<ICustomerOrderService>());
+
+            var order = new CustomerOrder { Id = "order1", IsCancelled = false, InPayments = [] };
+
+            //Act
+            await handler.Handle(new OrderChangedEvent([new GenericChangedEntry<CustomerOrder>(order, order, EntryState.Modified)]));
+
+            //Assert
+            Assert.Equal(0, capture.EnqueueCount);
+        }
+
+        [Fact]
+        public async Task CancelPaymentJobHandler_DelegatesToTheEventHandler()
+        {
+            //Arrange
+            // The job handlers are pure delegation: the logic stays on the event handler, which also remains the
+            // target of background jobs enqueued by an earlier version. One of them is covered as a representative.
+            var eventHandlerMock = new Mock<CancelPaymentOrderChangedEventHandler>(Mock.Of<ICustomerOrderService>());
+            var jobArguments = new[] { new PaymentToCancelJobArgument { CustomerOrderId = "order1", PaymentId = "payment1" } };
+
+            eventHandlerMock
+                .Setup(x => x.TryToCancelOrderPaymentsAsync(jobArguments))
+                .Returns(Task.CompletedTask);
+
+            var handler = new CancelPaymentJobHandler(eventHandlerMock.Object);
+
+            //Act
+            await handler.Execute(new CancelPaymentJobPayload { JobArguments = jobArguments }, context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            eventHandlerMock.Verify(x => x.TryToCancelOrderPaymentsAsync(jobArguments), Times.Once);
+        }
+
+        private static ISettingsManager CreateSettingsManager(bool enabled)
+        {
+            var settingsManager = new Mock<ISettingsManager>();
+            settingsManager
+                .Setup(x => x.GetObjectSettingAsync(ModuleConstants.Settings.General.LogOrderChanges.Name, It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = enabled });
+
+            return settingsManager.Object;
+        }
+
+        // Captures what a handler enqueued through the static BackgroundJob facade. IBackgroundJob is registered
+        // Scoped here exactly as the engine module registers it, so this also proves the facade's per-call scope
+        // resolves it - the handlers themselves are root-resolved and must never hold it.
+        private sealed class EnqueueCapture : IDisposable
+        {
+            private readonly ServiceProvider _provider;
+
+            public EnqueueCapture()
+            {
+                Setup<LogOrderChangesJobHandler>();
+                Setup<CancelPaymentJobHandler>();
+
+                var services = new ServiceCollection();
+                services.AddScoped(_ => BackgroundJobMock.Object);
+                _provider = services.BuildServiceProvider(validateScopes: true);
+
+                BackgroundJob.Initialize(_provider);
+            }
+
+            public Mock<IBackgroundJob> BackgroundJobMock { get; } = new();
+
+            public object Payload { get; private set; }
+
+            public int EnqueueCount { get; private set; }
+
+            public void Dispose()
+            {
+                _provider.Dispose();
+            }
+
+            private void Setup<THandler>()
+                where THandler : class
+            {
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<THandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) =>
+                    {
+                        Payload = payload;
+                        EnqueueCount++;
+                    })
+                    .ReturnsAsync("job-id");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5490
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Orders_3.1014.0-pr-503-ce6d.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inventory reservations, payment voids/refunds, audit logs, and customer notifications off the request thread; behavior is intended to stay the same via delegation, but the job infrastructure and serialization contract changed.
> 
> **Overview**
> Order-changed **async work** (inventory, payment cancel/refund, change logs, notifications) no longer uses direct **Hangfire** `BackgroundJob.Enqueue` on handler methods. It enqueues via the platform **`BackgroundJob` facade** and typed **`IBackgroundJobHandler`** jobs registered in **`Module.cs`** as **non-triggerable**.
> 
> Each flow builds a **serializable payload** and calls `BackgroundJob.Enqueue<THandler>(payload)` so root-lifetime event handlers do not capture scoped **`IBackgroundJob`**. **Inventory adjustment** uses **`AdjustInventoryJobPayload`** (order projection + line items) instead of the full order graph, so job JSON survives serialization without polymorphic types. Existing handler methods remain the implementation; thin job handlers delegate to them for jobs enqueued by older versions.
> 
> **Platform** packages and **`module.manifest`** move to **3.1052.0**; **`VirtoCommerce.Platform.Hangfire`** is dropped from the Data project. **`BackgroundJobEnqueueTests`** cover enqueue behavior, inventory payload round-trip, and handler delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6de09b566707f29be4bfce2b0f33a24f0f4378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->